### PR TITLE
chore(repo) init pnpm workspace and repo meta

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,75 @@
-docs/
+# Dependencies
+node_modules/
+.pnpm-debug.log*
+
+# Environment files
 .env
+.env.local
+.env.*.local
+
+# Build outputs
+dist/
+build/
+.next/
+out/
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons
+build/Release
+
+# Dependency directories
+jspm_packages/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local development
+.env.development.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# Talvra - Microservice Learning App
+
+A monorepo containing a microservice learning application that helps students process and study course content with AI-generated study aids.
+
+## Architecture
+
+This is a pnpm workspace monorepo with:
+
+- **Frontend**: React with Vite, React Router v6, styled-components, React Query
+- **Backend**: Node.js/Python microservices with Neon Postgres, Redis Streams, Azure Blob Storage
+- **No ORM**: Raw SQL migrations for database schema management
+
+## Project Structure
+
+```
+├── apps/                    # Application entrypoints
+│   └── web/                # React frontend app
+├── services/               # Backend microservices
+│   ├── api-gateway/       # Main API gateway (Node.js/TypeScript)
+│   ├── auth-service/      # Authentication service (Node.js/TypeScript)
+│   ├── canvas-service/    # Canvas LMS integration (Node.js/TypeScript)
+│   ├── ingestion-service/ # Document processing (Python)
+│   ├── ai-service/        # AI study aids generation (Python)
+│   ├── media-service/     # Video/TTS generation (Python)
+│   └── notification-service/ # Email notifications (Node.js/TypeScript)
+├── packages/              # Shared packages
+│   ├── talvra-ui/        # Shared UI primitives (styled-components)
+│   ├── talvra-api/       # API client hooks (React Query)
+│   ├── talvra-routes/    # Generated route constants
+│   ├── talvra-hooks/     # Shared React hooks
+│   └── talvra-constants/ # Design tokens and constants
+├── migrations/            # Database migrations by bounded context
+├── docs/                  # Documentation and process guides
+└── infra/                # Infrastructure and deployment configs
+```
+
+## Path Aliases
+
+This project uses TypeScript path aliases for clean imports:
+
+- `@/` - Root src directory
+- `@ui` - UI primitives from `packages/talvra-ui`
+- `@hooks` - Shared hooks from `packages/talvra-hooks`
+- `@constants` - Constants from `packages/talvra-constants`
+- `@routes` - Generated route constants from `packages/talvra-routes`
+- `@api` - API hooks from `packages/talvra-api`
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js >=18
+- pnpm >=8
+- Docker and Docker Compose (for local services)
+
+### Installation
+
+1. Install dependencies:
+```bash
+pnpm install
+```
+
+2. Start local infrastructure:
+```bash
+docker compose -f infra/docker-compose.yml up -d
+```
+
+3. Run the development environment:
+
+Frontend:
+```bash
+pnpm --filter web dev
+```
+
+API Gateway:
+```bash
+pnpm --filter ./services/api-gateway dev
+```
+
+### Available Commands
+
+- `pnpm install` - Install all dependencies
+- `pnpm -r list` - List all workspace packages
+- `pnpm validate:process` - Validate process documentation
+- `pnpm codegen` - Generate API types and routes
+- `pnpm demo:e2e` - Run end-to-end demo
+
+## Development Workflow
+
+This project follows a structured task-based workflow. See `docs/tasks.json` for the complete build plan.
+
+Each task:
+1. Creates a feature branch
+2. Implements specific functionality
+3. Ensures the app remains runnable
+4. Opens a PR with proper documentation
+5. Passes CI checks before merge
+
+## Key Principles
+
+- **No raw HTML tags** in frontend Areas - use `@ui` primitives only
+- **No ORM** - use raw SQL migrations for database schema
+- **Heavy typing** - TypeScript throughout with proper contracts
+- **Small files** - Keep modules under ~100 lines
+- **Unified error handling** - Consistent error shapes across services
+- **Request ID propagation** - Trace requests across all services
+
+## Documentation
+
+- Process handbook: `docs/handbook.json`
+- Task plan: `docs/tasks.json`
+- Frontend architecture: `docs/frontend/`
+- Backend architecture: `docs/backend/`
+- Canvas integration: `docs/integrations/canvas-api.md`
+
+## Health Checks
+
+Once services are running:
+
+- Frontend: http://localhost:3000
+- API Gateway: `curl localhost:3001/health`
+- Auth Service: `curl localhost:4001/auth/health`
+
+---
+
+Built with ❤️ for better learning experiences.

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -1,0 +1,292 @@
+Perfect. Here’s a single, consolidated doc you can drop in as docs/process.md.
+
+# Process Handbook
+
+One file to run the project. How we branch, review, test, release, and operate.
+
+## 1. Pull requests
+
+Principles
+- One logical change per PR
+- Keep PRs small
+- Code, tests, and docs move together
+- Update OpenAPI and run codegen when endpoints change
+
+Branches
+- Create a branch per task
+- Name format examples
+  - phase3/ingestion-pptx
+  - frontend/courses-page
+  - backend/auth-argon2
+
+PR checklist
+- Summary of what changed and why
+- Scope of affected services or areas
+- How it was tested
+  - unit
+  - contract
+  - integration
+  - screenshots or logs if UI changed
+- Rollback plan
+- Boxes to tick
+  - [ ] Docs updated
+  - [ ] OpenAPI updated and codegen ran
+  - [ ] Lint and types pass
+  - [ ] Tests added or updated
+  - [ ] Frontend has no raw tags in Areas
+  - [ ] Navigation uses FRONT_ROUTES and buildPath
+
+Reviews
+- At least one owner from each touched area
+- CI must be green before merge
+
+## 2. Commits
+
+Format
+`type(scope): short summary`
+
+Types
+- feat
+- fix
+- refactor
+- perf
+- test
+- docs
+- chore
+- build
+- ci
+
+Rules
+- Imperative mood
+- Subject under 72 chars
+- Reference an issue or task id when useful
+
+Examples
+- feat(auth): add Argon2id hashing
+- fix(ingestion): handle ppt with embedded video
+- docs(frontend): add routing constants guide
+
+## 3. Ownership
+
+Owners per path
+- apps/web and packages/talvra-ui and talvra-api are frontend owners
+- services/* and migrations/* are backend owners
+- docs/* are product owners
+
+Use a CODEOWNERS file if you prefer automation. This section is the single source of truth.
+
+## 4. CI gates
+
+Quality bars on every PR
+- ESLint and formatting pass
+- Type check pass
+- Unit tests pass with 80 percent lines coverage
+- Contract tests pass for touched endpoints
+- Integration smoke passes for core flow
+- OpenAPI diff approved when endpoints change
+- Frontend guardrails enforced
+  - no raw tags in Areas
+  - routes use FRONT_ROUTES and buildPath
+
+## 5. Error catalog
+
+Shape
+```json
+{
+  "error": {
+    "code": "string",
+    "message": "human readable",
+    "details": {},
+    "request_id": "uuid"
+  }
+}
+
+Codes
+	•	UNAUTHENTICATED 401
+	•	FORBIDDEN 403
+	•	NOT_FOUND 404
+	•	INVALID_ARGUMENT 400
+	•	CONFLICT 409
+	•	RATE_LIMITED 429
+	•	INTERNAL 500
+
+Guidelines
+	•	Do not leak internals
+	•	Always include request_id
+	•	Map validation failures to INVALID_ARGUMENT with field hints
+
+6. Rate limits
+
+Auth
+	•	Login 5 per minute per ip
+	•	OAuth callback 10 per minute per ip
+
+Canvas sync
+	•	Manual sync 2 per minute per user
+
+Search
+	•	60 per minute per user
+
+Policy
+	•	Return 429 with Retry After header
+	•	Log structured event with user_id and route
+
+7. Security and data
+
+Secrets
+	•	Only from env or secret manager
+	•	Rotate on schedule
+
+PII
+	•	School email only
+	•	Canvas tokens encrypted at rest
+
+Retention
+	•	Documents and media 180 days
+	•	Logs 90 days
+	•	Delete on request within 7 days
+
+Access
+	•	Clients get signed urls only
+	•	Least privilege for service tokens
+
+8. Runbooks
+
+Reprocess a document
+	•	Publish ingest.request with the same doc_id
+	•	Workers are idempotent
+
+Stuck consumer
+	•	Claim pending messages older than timeout to a fresh consumer
+	•	Restart worker and watch lag
+
+High error rate on AI
+	•	Switch API key in env
+	•	Enable backoff and circuit breaker
+
+Blob write failures
+	•	Serve cached markdown from Postgres if available
+	•	Queue write for later
+
+Secret rotation
+	•	Update env
+	•	Restart service
+	•	Verify health and smoke tests
+
+Purge old logs
+	•	Delete where ts is older than 90 days
+
+9. Releases
+
+Versioning
+	•	Semantic versioning for services
+	•	Tag images with semver and git sha
+
+Changelog
+	•	Generate from commit types
+	•	Summarize features, fixes, and breaking changes
+
+Flow
+	•	Merge to main
+	•	CI builds and tags images
+	•	Deploy to staging
+	•	Run smoke tests
+	•	Promote to prod
+
+10. ADRs
+
+When to write
+	•	New service
+	•	New datastore or queue
+	•	Cross cutting change
+
+Template
+	•	Context
+	•	Options considered
+	•	Decision
+	•	Consequences
+
+File location
+	•	docs/process/adr/NNN-title.md
+
+11. Frontend guardrails
+
+Architecture
+	•	React with Vite
+	•	React Router v6
+	•	styled components
+	•	react query
+
+Rules
+	•	Areas folder for features
+	•	No raw HTML tags in pages or Area components
+	•	Use Talvra UI primitives from the shared UI package
+	•	All data fetching uses useAPI on top of react query
+	•	Frontend routes live in src/app/routes.ts as a single source of truth
+	•	API routes live in packages/talvra-routes and come from OpenAPI codegen
+
+Performance
+	•	First load under 200 kb gzip
+	•	Route chunk under 100 kb gzip
+	•	Lazy load Areas
+	•	Memoize heavy lists
+	•	Avoid inline functions in hot paths
+
+Accessibility
+	•	Keyboard reachable controls
+	•	Visible focus states
+	•	Labels for inputs
+	•	Contrast meets AA
+	•	Use Text component with a semantic prop when needed
+
+12. Backend guardrails
+	•	No ORM. Raw SQL migrations
+	•	Idempotent workers
+	•	Small payloads on streams
+	•	Encrypt Canvas tokens
+	•	Rate limit auth and sync
+	•	Request ids through logs
+	•	Health endpoints per service
+
+13. Codegen and sync
+
+Backend to frontend
+	•	API Gateway serves OpenAPI at /openapi.json
+	•	Run codegen to produce
+	•	typed clients and request or response types in talvra-api
+	•	route constants in talvra-routes
+
+Frontend routes
+	•	Add new pages only in src/app/routes.ts
+	•	Build React Router config from those constants
+
+14. Checklists
+
+Add a new backend endpoint
+	•	Write handler and contract
+	•	Update OpenAPI
+	•	Add tests unit and contract
+	•	Run codegen
+	•	Update docs
+
+Add a new frontend page
+	•	Create component in the Area
+	•	Add a route object in src/app/routes.ts
+	•	Use Talvra UI primitives only
+	•	Use useAPI for data
+	•	Add tests and screenshots
+
+Add a new stream message
+	•	Define schema
+	•	Validate on publish and on consume
+	•	Make handlers idempotent
+	•	Add integration test with Redis
+
+PR for AI agent
+	•	Create branch phaseX or frontend or backend
+	•	Describe what changed and why
+	•	Explain how you tested it and results
+	•	Ensure CI is green
+	•	I will review and merge
+
+⸻

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,565 @@
+# Build Plan and Task Tracker
+
+This file is the single source of truth for the build order. The AI works task by task, creates a branch, opens a PR, and marks each task as done in `docs/tasks.json` after merge.
+
+You can run the app at each step and see something on screen or via a health endpoint.
+
+## How to use this file
+
+- The agent takes the next task with status todo
+- Creates a branch named as specified in the task
+- Follows the steps and acceptance checks
+- Opens a PR with the title and body template
+- After you merge, the agent flips the task to done in `docs/tasks.json` and continues
+
+## Conventions
+
+- Monorepo with pnpm workspaces
+- Frontend is React with Vite and React Router
+- No Tailwind
+- Shared UI primitives live in `packages/talvra-ui` and are the only place where raw HTML tags exist
+- Frontend uses `@tanstack/react-query` and a typed `useAPI` hook in `packages/talvra-api`
+- Backend is microservices. Database is Neon Postgres. Storage is Azure Blob. Queue is Redis Streams
+- No ORM. SQL migrations live under `/migrations/<bounded_context>`
+- Process rules live in `docs/process.md` and `docs/process.json`. A validator ensures the JSON stays valid
+
+---
+
+## Phase 0 - Repo and CI basics
+
+### T000 - Initialize monorepo and workspace
+- Branch: tooling/init-monorepo
+- Paths: `package.json`, `pnpm-workspace.yaml`, `.editorconfig`, `.gitignore`, `README.md`
+- Steps
+  - Create pnpm workspace at repo root
+  - Add scripts placeholders
+  - Add `@` path alias guidance in README
+- Run checks
+  - `pnpm -v`
+  - `pnpm install`
+- Acceptance
+  - `pnpm install` succeeds at root
+  - Workspace is recognized. `pnpm -r list` shows zero packages but no errors
+- PR title
+  - chore(repo) init pnpm workspace and repo meta
+- PR body
+  - Why: set the foundation for multi apps
+  - What changed: workspace files and repo meta
+  - Tests: install ok
+
+### T001 - Add CI workflow skeleton
+- Branch: tooling/ci-skeleton
+- Paths: `.github/workflows/ci.yml`
+- Steps
+  - Add a single job that checks out code and runs `pnpm install`
+- Acceptance
+  - CI passes on PR
+- PR title
+  - ci: add workflow skeleton
+- PR body
+  - Why: early CI feedback
+  - Tests: green run on PR
+
+### T002 - Process handbook and validator
+- Branch: tooling/process-handbook
+- Paths: `docs/process.md`, `docs/process.json`, `scripts/validate-process-json.ts`, `package.json`, `.github/workflows/ci.yml`
+- Steps
+  - Add process handbook markdown and JSON
+  - Create validator script with zod
+  - Add `pnpm run validate:process` and call it in CI
+- Run checks
+  - `pnpm add -D tsx zod`
+  - `pnpm run validate:process`
+- Acceptance
+  - Validator reports `process.json valid`
+  - CI runs the validator
+- PR title
+  - docs(process) add handbook and JSON with validator
+- PR body
+  - Why: single source of truth for rules
+  - Tests: validator pass and CI hook
+
+---
+
+## Phase 1 - Frontend base you can run
+
+### T010 - Scaffold Vite React app and structure
+- Branch: web/scaffold
+- Paths: `apps/web/**`, `packages/configs/**`, `tsconfig.base.json`
+- Steps
+  - Create `apps/web` with Vite React TypeScript template
+  - Add `vite.config.ts` with path aliases to `@`, `@ui`, `@hooks`, `@constants`, `@routes`, `@api`
+  - Add `tsconfig.json` that maps those aliases
+  - Add `src/Areas` folder with `Admin` and `Courses`
+  - Add `src/app/AppProvider.tsx`, `src/app/AppRoutes.tsx`, `src/app/routes.ts`
+- Run checks
+  - `pnpm --filter web dev`
+- Acceptance
+  - Dev server starts and shows a simple Admin page
+- PR title
+  - feat(web) scaffold Vite app with Areas and routes skeleton
+- PR body
+  - What: Vite app, routes, Areas folders
+  - Tests: `pnpm --filter web dev` shows Admin page
+
+### T011 - Shared UI primitives package
+- Branch: web/ui-primitives
+- Paths: `packages/talvra-ui/**`, `apps/web/.eslintrc.cjs`, `packages/configs/.eslintrc.base.cjs`
+- Steps
+  - Create `talvra-ui` with primitives Surface, Stack, Text, Card, Button, Link using styled-components
+  - Set ESLint rule that forbids raw tags in `apps/web/src` outside `talvra-ui`
+- Acceptance
+  - Admin page renders using only `@ui` imports
+  - ESLint fails if a raw tag is used in Areas
+- PR title
+  - feat(ui) add Talvra UI primitives and lint guard
+- PR body
+  - What: primitives and guard
+  - Tests: render Admin, lint rule triggers on raw tag sample
+
+### T012 - Frontend route constants as single source of truth
+- Branch: web/front-routes-constants
+- Paths: `apps/web/src/app/routes.ts`, `apps/web/src/app/AppRoutes.tsx`, `packages/talvra-hooks/src/useTalvraNav.ts`
+- Steps
+  - Define FRONT_ROUTES with lazy-loaded components and metadata
+  - Add `buildPath` helper
+  - Add `useTalvraNav` hook to navigate by key
+- Acceptance
+  - Navigating to courses and course detail works through constants
+- PR title
+  - feat(web) add FRONT_ROUTES constants and typed navigation
+- PR body
+  - What: routes file, helper, hook
+  - Tests: dev server navigation
+
+### T013 - React Query and useAPI hook package
+- Branch: web/useapi
+- Paths: `packages/talvra-api/src/useAPI.ts`, `apps/web/src/app/AppProvider.tsx`
+- Steps
+  - Add QueryClientProvider in AppProvider
+  - Implement `useAPI` that takes a RouteDef and returns data, metadata, and run function
+- Acceptance
+  - A test route calling a mock endpoint returns data in a sample component
+- PR title
+  - feat(api) add typed useAPI on react query
+- PR body
+  - What: provider and hook
+  - Tests: sample GET works
+
+---
+
+## Phase 2 - Backend base you can run
+
+### T020 - Docker compose for local stack
+- Branch: infra/compose-base
+- Paths: `infra/docker-compose.yml`, `infra/redis/**`, `infra/azurite/**`, `.env.example`
+- Steps
+  - Add Postgres service for local dev or point to Neon via env
+  - Add Redis and Azurite
+  - Add networks and ports
+- Acceptance
+  - `docker compose up -d` brings up services
+- PR title
+  - infra: add compose for Postgres Redis Azurite
+- PR body
+  - What: compose file and env example
+  - Tests: services healthy
+
+### T021 - API Gateway service skeleton
+- Branch: backend/gateway-skeleton
+- Paths: `services/api-gateway/**`
+- Steps
+  - Node TypeScript service with GET `/health` and a proxy placeholder
+  - Request id on each response
+- Acceptance
+  - `curl localhost:3001/health` returns ok true
+- PR title
+  - feat(gateway) skeleton with health and request id
+- PR body
+  - What: service base
+  - Tests: curl result and logs
+
+### T022 - Auth service skeleton
+- Branch: backend/auth-skeleton
+- Paths: `services/auth-service/**`, `migrations/auth/**`
+- Steps
+  - Add users and sessions tables migrations
+  - Add POST `/auth/signup`, `/auth/login`, GET `/auth/session` with in memory session for now
+- Acceptance
+  - Sign up and login work against local Postgres
+- PR title
+  - feat(auth) service skeleton and basic auth endpoints
+- PR body
+  - What: endpoints and migrations
+  - Tests: curl paths return expected
+
+### T023 - Gateway to Auth integration with cookies
+- Branch: backend/gateway-auth-integration
+- Paths: `services/api-gateway/**`
+- Steps
+  - Proxy `/auth/*` to Auth
+  - Set and read HttpOnly cookie session
+- Acceptance
+  - Login through gateway sets session cookie
+  - GET `/auth/session` shows logged in state
+- PR title
+  - feat(gateway) proxy auth and session cookies
+- PR body
+  - What: reverse proxy and cookie handling
+
+---
+
+## Phase 3 - Canvas integration with fixtures first
+
+### T030 - Canvas service skeleton and OAuth placeholders
+- Branch: backend/canvas-skeleton
+- Paths: `services/canvas-service/**`, `migrations/canvas/**`
+- Steps
+  - Tables for `canvas_courses` and `canvas_assignments`
+  - Endpoints: POST `/canvas/connect` placeholder, POST `/canvas/sync`, GET `/canvas/courses`, GET `/canvas/assignments`
+  - For now, `sync` reads fixture JSON and inserts rows
+- Acceptance
+  - GET courses and assignments return fixture data
+- PR title
+  - feat(canvas) service skeleton with fixture sync
+- PR body
+  - What: tables and endpoints
+  - Tests: sync then read
+
+### T031 - Gateway routes for Canvas
+- Branch: backend/gateway-canvas-proxy
+- Paths: `services/api-gateway/**`
+- Steps
+  - Proxy `/canvas/*` to Canvas service
+- Acceptance
+  - Frontend can call `/api/canvas/courses` and get fixture data
+- PR title
+  - feat(gateway) proxy canvas routes
+- PR body
+  - What: proxy rules
+
+### T032 - Frontend Courses Area basic list
+- Branch: web/courses-list
+- Paths: `apps/web/src/Areas/Courses/**`
+- Steps
+  - Add `useTalvraCourses` hook that calls GET_ALL_COURSES route
+  - Render a list using `@ui` primitives only
+- Acceptance
+  - Visiting `/courses` shows fixture courses
+- PR title
+  - feat(web) courses list using useAPI and route constants
+- PR body
+  - What: hook and list
+  - Tests: manual route visit shows data
+
+---
+
+## Phase 4 - Ingestion pipeline start
+
+### T040 - Ingestion service skeleton and migrations
+- Branch: backend/ingestion-skeleton
+- Paths: `services/ingestion-service/**`, `migrations/documents/**`
+- Steps
+  - Tables for documents
+  - Endpoints: POST `/ingestion/start`, GET `/documents/:id`
+  - Add Redis stream names and consumer group
+- Acceptance
+  - Posting start returns a doc id and enqueues a message
+- PR title
+  - feat(ingestion) service skeleton with Redis stream
+- PR body
+  - What: endpoints and queue
+
+### T041 - Minimal extractor for PDF and DOCX to Markdown plus JSON
+- Branch: backend/ingestion-extractor
+- Paths: `services/ingestion-service/src/**`
+- Steps
+  - Implement adapters to extract text and headings
+  - Save markdown and structure.json to Azurite
+  - Upsert `documents` row
+- Acceptance
+  - `POST /ingestion/start` with a PDF fixture produces blob files
+  - `GET /documents/:id` returns blob urls
+- PR title
+  - feat(ingestion) extract PDF and DOCX to md and json
+- PR body
+  - What: adapters and blob store
+  - Tests: run with fixture
+
+### T042 - Frontend: view generated notes for a document
+- Branch: web/documents-view
+- Paths: `apps/web/src/Areas/Courses/**`, `packages/talvra-routes/**`
+- Steps
+  - Add route constants to fetch documents and notes
+  - Add page under Courses to show a document’s title and markdown link using `@ui`
+- Acceptance
+  - Clicking a sample course shows a document with links
+- PR title
+  - feat(web) document view screen
+- PR body
+  - What: page and routes
+
+---
+
+## Phase 5 - AI outputs
+
+### T050 - AI service skeleton with mocked LLM
+- Branch: backend/ai-skeleton
+- Paths: `services/ai-service/**`, `migrations/ai/**`
+- Steps
+  - Add tables `notes`, `flashcards`
+  - Endpoint POST `/ai/start` takes doc and produces markdown notes, slides markdown, and flashcards JSON with a mock LLM
+- Acceptance
+  - Calling start writes rows and blob files
+- PR title
+  - feat(ai) service skeleton with mock outputs
+- PR body
+  - What: endpoints and tables
+
+### T051 - Frontend slides and flashcards screens
+- Branch: web/slides-flashcards
+- Paths: `apps/web/src/Areas/Courses/**`
+- Steps
+  - Render slides markdown with reveal.js client side
+  - Render flashcards with simple flip cards using `@ui`
+- Acceptance
+  - A processed document shows notes, slides, and flashcards
+- PR title
+  - feat(web) slides and flashcards views
+- PR body
+  - What: pages wired to AI outputs
+
+---
+
+## Phase 6 - Media pipeline
+
+### T060 - Media service skeleton and TTS adapter interface
+- Branch: backend/media-skeleton
+- Paths: `services/media-service/**`, `migrations/media/**`
+- Steps
+  - Endpoint POST `/media/start` and GET `/media/:doc_id`
+  - Store MP4 and thumbnail in Blob
+  - Use a stub TTS that speaks a short phrase per slide
+- Acceptance
+  - Calling start generates an MP4 and a thumbnail
+- PR title
+  - feat(media) service skeleton with stub TTS
+- PR body
+  - What: MP4 pipeline and storage
+
+### T061 - Frontend: watch generated video
+- Branch: web/video-player
+- Paths: `apps/web/src/Areas/Courses/**`, `@ui` Video component
+- Steps
+  - Add `Video` primitive that wraps the player
+  - Course document page shows a playable MP4
+- Acceptance
+  - MP4 plays in browser
+- PR title
+  - feat(web) video playback for document
+- PR body
+  - What: primitive and page
+
+---
+
+## Phase 7 - Search and reminders
+
+### T070 - Embedding search with Redis
+- Branch: backend/search-embeddings
+- Paths: `services/ai-service/**` or a new search worker, `services/api-gateway/**`
+- Steps
+  - Chunk notes and store embeddings in RedisSearch
+  - GET `/search?q=` returns matches with doc ids
+- Acceptance
+  - A known term returns the right note chunk
+- PR title
+  - feat(search) semantic search over notes
+- PR body
+  - What: embedding index and endpoint
+
+### T071 - Notification service and assignment reminders
+- Branch: backend/notify-reminders
+- Paths: `services/notification-service/**`, `migrations/notifications/**`
+- Steps
+  - Read assignments due_at and schedule reminders
+  - Send email via SMTP or provider
+- Acceptance
+  - A task creates a scheduled reminder and sends a test email to dev inbox
+- PR title
+  - feat(notify) assignment reminders
+- PR body
+  - What: scheduler and sender
+
+### T072 - Frontend: reminders settings screen
+- Branch: web/reminders-settings
+- Paths: `apps/web/src/Areas/Admin/**`
+- Steps
+  - Simple toggle and schedule settings using `@ui` and `useAPI`
+- Acceptance
+  - Saving settings hits notify service and persists
+- PR title
+  - feat(web) reminders settings UI
+- PR body
+  - What: admin UI and routes
+
+---
+
+## Phase 8 - Canvas real OAuth and file ingestion
+
+### T080 - Canvas OAuth connect flow
+- Branch: backend/canvas-oauth
+- Paths: `services/canvas-service/**`
+- Steps
+  - Real OAuth handshake with Canvas
+  - Encrypt and store tokens
+- Acceptance
+  - Connect flow completes and tokens live in DB
+- PR title
+  - feat(canvas) real OAuth and token storage
+- PR body
+  - What: OAuth endpoints and crypto
+
+### T081 - Canvas sync to ingestion bridge
+- Branch: backend/canvas-to-ingestion
+- Paths: `services/canvas-service/**`, `services/ingestion-service/**`
+- Steps
+  - On sync, enumerate module items and enqueue `ingest.request` for new files
+- Acceptance
+  - New files appear as documents after pipeline runs
+- PR title
+  - feat(canvas) enqueue ingestion for new module items
+- PR body
+  - What: event emission and dedupe
+
+---
+
+## Phase 9 - Logging and observability
+
+### T090 - Logging service and structured logs to Postgres
+- Branch: backend/logging-service
+- Paths: `services/logging-service/**`, `migrations/logs/**`
+- Steps
+  - POST `/logs` inserts log rows
+  - Add simple query endpoint for ops
+- Acceptance
+  - Services can log and you can query by request id
+- PR title
+  - feat(logs) structured logs service and storage
+- PR body
+  - What: endpoint and schema
+
+### T091 - Request id through all services
+- Branch: backend/request-id-plumbing
+- Paths: services gateways and clients
+- Steps
+  - Gateway injects X-Request-Id
+  - Downstream logs include it
+- Acceptance
+  - One request’s logs are traceable across services
+- PR title
+  - chore(observability) request id propagation
+- PR body
+  - What: header and logging
+
+---
+
+## Phase 10 - Compliance and hardening
+
+### T100 - Rate limits and error model
+- Branch: backend/rate-limits-errors
+- Paths: gateway and services where needed
+- Steps
+  - Implement rate limits per `docs/process.json`
+  - Return error shape as defined
+- Acceptance
+  - Hitting limits yields 429 with Retry After
+  - Errors include request_id
+- PR title
+  - chore(security) rate limits and unified error shape
+- PR body
+  - What: middleware and handlers
+
+### T101 - Data retention jobs
+- Branch: backend/retention-jobs
+- Paths: any worker service, migrations for retention tables if needed
+- Steps
+  - Scheduled jobs to prune old logs and stale blobs
+- Acceptance
+  - Dry run shows counts, then prune works on dev
+- PR title
+  - chore(data) retention jobs for logs and blobs
+- PR body
+  - What: scheduled tasks and safety checks
+
+---
+
+## Phase 11 - Codegen and sync
+
+### T110 - OpenAPI in gateway and frontend codegen
+- Branch: tooling/openapi-codegen
+- Paths: `services/api-gateway/**`, `packages/talvra-routes/**`, `packages/talvra-api/**`, `scripts/**`
+- Steps
+  - Serve `/openapi.json` that aggregates downstream specs or hand write a v1 spec
+  - Script to generate API route constants and types for the frontend
+- Acceptance
+  - `pnpm run codegen` updates routes and types
+- PR title
+  - tooling: OpenAPI and frontend codegen
+- PR body
+  - What: spec, generator, and wiring
+
+---
+
+## Phase 12 - Polishing and e2e
+
+### T120 - End to end demo data and flows
+- Branch: demo/e2e-flow
+- Paths: seed scripts and fixtures
+- Steps
+  - Seed a student, a course, a PDF, and produce notes and a video
+  - Document a one command demo in README
+- Acceptance
+  - One command brings up the stack and a clickable demo
+- PR title
+  - feat(demo) one command e2e with sample content
+- PR body
+  - What: seeds and demo script
+
+### T121 - Accessibility pass on core pages
+- Branch: web/a11y-pass
+- Paths: `apps/web/**`, `packages/talvra-ui/**`
+- Steps
+  - Ensure focus, roles, labels, contrast per rules
+- Acceptance
+  - Automated a11y checks pass on core pages
+- PR title
+  - chore(web) a11y improvements on core pages
+- PR body
+  - What: focus, labels, roles
+
+### T122 - Performance pass and lazy chunks
+- Branch: web/perf-chunks
+- Paths: `apps/web/**`
+- Steps
+  - Audit bundle sizes and ensure lazy Areas
+- Acceptance
+  - First load under 200 kb gzip, route chunks under 100 kb
+- PR title
+  - chore(web) code split Areas and tune bundles
+- PR body
+  - What: lazy routes and cleanup
+
+---
+
+## Running at each phase
+
+- Frontend dev
+  - `pnpm --filter web dev`
+- Gateway health
+  - `curl localhost:3001/health`
+- Auth test
+  - `curl -X POST localhost:4001/auth/signup`
+- Compose stack
+  - `docker compose -f infra/docker-compose.yml up -d`
+
+Each task above leaves the repo runnable. You will always see a page, an endpoint, or a result.

--- a/docs/backend/ENGINEERING.md
+++ b/docs/backend/ENGINEERING.md
@@ -1,0 +1,529 @@
+Here is a complete technical.md you can drop into docs/backend/.
+
+# Backend Technical Engineering Doc
+
+Scope
+- Microservices that ingest course content, generate study aids, and expose clean APIs to the React app.
+- Services are replaceable, small, and testable. No service depends on a live external in unit tests.
+- Database is Neon Postgres with SQL migrations. No ORM.
+- Storage is Azure Blob Storage.
+- Queue is Redis Streams. Embedding search can use RediSearch.
+
+## 1. Stack and conventions
+
+Languages
+- Node TypeScript for API Gateway, Auth, Canvas, Notification.
+- Python for Ingestion, AI, Media.
+- Go or Rust optional for Logging service.
+
+Common rules
+- Files target 100 lines max. Split modules aggressively.
+- Strict typing. No implicit any.
+- All external calls go through adapter interfaces with fakes for tests.
+- Config from env. Docker compose wires env to containers.
+- Import aliases use "@/..." across services for shared code clarity.
+
+Ports
+- API Gateway 3001
+- Auth 4001
+- Canvas 4002
+- Ingestion 4003
+- AI 4004
+- Media 4005
+- Notification 4006
+- Logging 4010
+
+## 2. Repository layout
+
+repo-root/
+services/
+api-gateway/
+auth-service/
+canvas-service/
+ingestion-service/
+ai-service/
+media-service/
+notification-service/
+logging-service/
+packages/
+backend-configs/        # eslint, tsconfig bases, mypy, ruff, pre-commit
+backend-shared/         # small cross service utils, ids, json, http, typing
+infra/
+docker-compose.yml
+redis/
+azurite/
+docs/
+backend/
+product.md
+technical.md
+migrations/
+auth/
+canvas/
+documents/
+ai/
+media/
+notifications/
+logs/
+
+Each service has
+
+src/
+app/            # http handlers or cli entrypoints
+domain/         # pure logic, use cases
+infra/          # adapters: db, blob, queue, http
+contracts/      # request and response types, validation
+tests/          # unit and contract tests
+
+## 3. Environment variables
+
+Global
+- POSTGRES_URL
+- REDIS_URL
+- AZURE_STORAGE_CONNECTION_STRING
+- LOG_LEVEL
+
+Auth
+- JWT_SECRET
+- GOOGLE_CLIENT_ID
+- GOOGLE_CLIENT_SECRET
+
+Canvas
+- CANVAS_BASE_URL
+- CANVAS_CLIENT_ID
+- CANVAS_CLIENT_SECRET
+
+AI
+- OPENAI_API_KEY
+
+Media
+- TTS_PROVIDER
+- ELEVENLABS_API_KEY or AWS_POLLY_REGION etc
+- FFMPEG_PATH if not on PATH
+
+Notification
+- SMTP_HOST SMTP_USER SMTP_PASS or PUSH keys
+
+## 4. Database schemas and migrations
+
+Principles
+- One schema folder per bounded context under /migrations.
+- Use raw SQL files with increasing numeric prefixes.
+- Prefer explicit indexes. Use JSONB only for flexible payloads.
+- Ids are UUID v4 generated in the service.
+
+Tables
+
+– migrations/auth/001_users.sql
+CREATE TABLE users (
+id UUID PRIMARY KEY,
+school_email TEXT UNIQUE NOT NULL,
+password_hash TEXT,
+google_id TEXT UNIQUE,
+canvas_user_id TEXT UNIQUE,
+created_at TIMESTAMP DEFAULT NOW(),
+updated_at TIMESTAMP DEFAULT NOW()
+);
+
+– migrations/auth/002_sessions.sql
+CREATE TABLE sessions (
+id UUID PRIMARY KEY,
+user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+token TEXT UNIQUE NOT NULL,
+expires_at TIMESTAMP NOT NULL,
+created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_sessions_user ON sessions(user_id);
+
+– migrations/canvas/001_courses.sql
+CREATE TABLE canvas_courses (
+id UUID PRIMARY KEY,
+user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+canvas_course_id TEXT,
+name TEXT,
+term TEXT,
+start_date DATE,
+end_date DATE
+);
+CREATE INDEX idx_courses_user ON canvas_courses(user_id);
+
+– migrations/canvas/002_assignments.sql
+CREATE TABLE canvas_assignments (
+id UUID PRIMARY KEY,
+course_id UUID REFERENCES canvas_courses(id) ON DELETE CASCADE,
+canvas_assignment_id TEXT,
+title TEXT,
+due_at TIMESTAMP,
+status TEXT
+);
+CREATE INDEX idx_assignments_course ON canvas_assignments(course_id);
+CREATE INDEX idx_assignments_due ON canvas_assignments(due_at);
+
+– migrations/documents/001_documents.sql
+CREATE TABLE documents (
+id UUID PRIMARY KEY,
+user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+course_id UUID REFERENCES canvas_courses(id),
+title TEXT,
+kind TEXT,                        – pdf docx pptx etc
+blob_url TEXT,
+markdown_url TEXT,
+json_url TEXT,
+created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_documents_user ON documents(user_id);
+
+– migrations/ai/001_notes.sql
+CREATE TABLE notes (
+id UUID PRIMARY KEY,
+doc_id UUID REFERENCES documents(id) ON DELETE CASCADE,
+markdown_url TEXT,
+summary JSONB,
+created_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_notes_doc ON notes(doc_id);
+
+– migrations/ai/002_flashcards.sql
+CREATE TABLE flashcards (
+id UUID PRIMARY KEY,
+doc_id UUID REFERENCES documents(id) ON DELETE CASCADE,
+cards JSONB
+);
+CREATE INDEX idx_flashcards_doc ON flashcards(doc_id);
+
+– migrations/media/001_media_assets.sql
+CREATE TABLE media_assets (
+id UUID PRIMARY KEY,
+doc_id UUID REFERENCES documents(id) ON DELETE CASCADE,
+kind TEXT,                        – image audio video
+blob_url TEXT,
+thumbnail_url TEXT
+);
+CREATE INDEX idx_media_doc ON media_assets(doc_id);
+
+– migrations/logs/001_logs.sql
+CREATE TABLE logs (
+id UUID PRIMARY KEY,
+ts TIMESTAMP DEFAULT NOW(),
+service TEXT,
+level TEXT,
+message TEXT,
+context JSONB
+);
+CREATE INDEX idx_logs_ts ON logs(ts);
+
+## 5. Messaging with Redis Streams
+
+Stream names
+- ingest.request
+- ingest.result
+- ai.request
+- ai.result
+- media.request
+- media.result
+- notify.request
+
+Consumer groups
+- ingestion:group
+- ai:group
+- media:group
+- notify:group
+
+Message contract examples
+
+```json
+// ingest.request
+{
+  "user_id": "uuid",
+  "doc_id": "uuid",
+  "source": "canvas",
+  "file_url": "blob-url",
+  "kind": "pdf|docx|pptx"
+}
+
+// ai.request
+{
+  "user_id": "uuid",
+  "doc_id": "uuid",
+  "markdown_url": "blob-url",
+  "json_url": "blob-url"
+}
+
+// media.request
+{
+  "user_id": "uuid",
+  "doc_id": "uuid",
+  "script": "string",
+  "assets": ["blob-url"]
+}
+
+Idempotency
+	•	Use doc_id as the natural id. Reprocessing is safe. Workers should upsert by doc_id.
+	•	Persist a dedupe key per message id if needed.
+
+Retry
+	•	Use XCLAIM after a visibility timeout.
+	•	Dead letter list per stream on repeated failures.
+
+6. Service contracts
+
+All endpoints are behind API Gateway. Gateway validates session and injects X-User-Id header and a short lived HMAC service token.
+
+API Gateway
+
+Responsibilities
+	•	Session auth with Auth Service.
+	•	Request routing and simple aggregation.
+	•	Rate limiting and request id.
+
+HTTP
+	•	GET /health
+	•	Proxies
+	•	/auth/*
+	•	/canvas/*
+	•	/ingestion/*
+	•	/ai/*
+	•	/media/*
+	•	/notify/*
+	•	/search
+
+Headers
+	•	X-Request-Id generated at edge.
+	•	X-User-Id from session.
+	•	X-Service-Token signed HMAC for downstream.
+
+Auth Service
+
+Endpoints
+	•	POST /auth/signup
+	•	POST /auth/login
+	•	GET /auth/oauth/google/start
+	•	GET /auth/oauth/google/callback
+	•	POST /auth/logout
+	•	GET /auth/session
+
+Responses
+	•	On login or signup set HttpOnly cookie session. Optionally return a short lived JWT for mobile.
+
+Security
+	•	Argon2id for password hashing with versioned params.
+	•	Lockout after repeated failures. Rate limit endpoints.
+
+Canvas Service
+
+Endpoints
+	•	POST /canvas/connect
+	•	POST /canvas/sync
+	•	GET /canvas/courses
+	•	GET /canvas/assignments
+
+Behavior
+	•	OAuth2 with Canvas. Store access and refresh tokens encrypted.
+	•	Sync pulls courses, assignments, module items. Writes to Postgres.
+	•	Emits ingest.request for files to process.
+
+Ingestion Service
+
+Endpoints
+	•	POST /ingestion/start
+	•	body: { doc_id, file_url, kind }
+	•	GET /documents/:id
+	•	returns document metadata, markdown_url, json_url, media list
+
+Workers
+	•	Normalize legacy formats with LibreOffice headless when needed.
+	•	Extract text, images, audio, video.
+	•	Write Markdown and JSON to Blob. Upsert documents row.
+
+JSON shape from extraction
+
+{
+  "title": "string",
+  "sections": [
+    {
+      "heading": "string",
+      "text": "string",
+      "media": [
+        { "type": "image|audio|video", "url": "blob-url", "alt": "optional" }
+      ],
+      "source": { "kind": "pdf|docx|pptx", "page": 3 }
+    }
+  ]
+}
+
+AI Service
+
+Endpoints
+	•	POST /ai/start
+	•	body: { doc_id, markdown_url, json_url }
+	•	GET /notes/:doc_id
+	•	GET /flashcards/:doc_id
+
+Workers
+	•	Summaries to notes.summary JSONB and notes.markdown_url.
+	•	Slides markdown to Blob.
+	•	Flashcards to flashcards.cards JSONB.
+
+Deterministic schemas for prompts. Validate before write.
+
+Media Service
+
+Endpoints
+	•	POST /media/start
+	•	body: { doc_id }
+	•	GET /media/:doc_id
+
+Workers
+	•	TTS provider adapter interface. Choose provider via env.
+	•	Compose video with ffmpeg. Store mp4 blob and thumbnail.
+
+Notification Service
+
+Endpoints
+	•	POST /notify/test
+	•	POST /notify/schedule
+	•	GET /notify/status/:id
+
+Workers
+	•	Read assignments due_at, schedule reminders.
+	•	Send via SMTP or push provider.
+
+Logging Service
+
+Endpoints
+	•	POST /logs
+	•	body: structured log message
+	•	GET /logs/query
+	•	filters by service, level, time
+
+Storage
+	•	Insert into logs table. Consider weekly partitions if volume grows.
+
+7. Storage layout in Azure Blob
+
+Containers
+	•	raw
+	•	derived
+	•	media
+
+Path patterns
+	•	raw/{user_id}/{doc_id}/{original_filename}
+	•	derived/{user_id}/{doc_id}/{artifact}.md
+	•	derived/{user_id}/{doc_id}/structure.json
+	•	media/{user_id}/{doc_id}/{asset_id}.{ext}
+	•	media/{user_id}/{doc_id}/thumb_{asset_id}.jpg
+
+Access
+	•	Services request short lived SAS for read or write as needed.
+	•	Clients only receive signed urls. Never share account keys.
+
+8. Security
+	•	Secrets only in env and secret managers. Never commit.
+	•	Encrypt Canvas tokens at rest. AES GCM with key from env or vault.
+	•	HttpOnly SameSite Lax cookies. Set Secure in production.
+	•	Validate all inbound JSON with zod or pydantic classes in contracts.
+	•	Strict CORS at the gateway.
+	•	Rate limit login, sync, and any expensive endpoints.
+	•	Request id flows through logs across services.
+
+9. Observability
+
+Logging format
+
+{
+  "ts": "2025-01-01T12:34:56Z",
+  "service": "ingestion",
+  "level": "info",
+  "message": "extracted markdown",
+  "context": { "doc_id": "uuid", "duration_ms": 842 }
+}
+
+Metrics
+	•	Expose /metrics per service if you add Prometheus later.
+
+Health
+	•	GET /health on every service returns { ok: true, uptime_ms, version }
+
+10. Testing strategy
+
+Unit
+	•	Domain and adapters use fakes for db, blob, queue, http.
+	•	No network in unit tests.
+
+Contract
+	•	Validate request and response shapes for each endpoint.
+	•	Validate stream message shapes on publish and on consume.
+
+Integration
+	•	docker compose up Postgres, Redis, Azurite.
+	•	Start a subset of services and run end to end scenarios.
+	•	Mock Canvas with fixtures or a small stub server.
+
+Fixtures
+	•	Place sample PDF, DOCX, PPTX in a test bucket or local folder for Azurite.
+
+CI
+	•	Lint, type check, unit, contract, integration.
+	•	Build images. Optionally smoke test compose up.
+
+11. Code generation
+
+Backend to frontend sync
+	•	API Gateway exposes OpenAPI spec at /openapi.json.
+	•	Codegen script generates:
+	•	typed clients and request or response types for frontend
+	•	route constant file for frontend API calls
+
+12. Versioning and compatibility
+	•	Prefix public endpoints with /v1.
+	•	Add new fields without breaking existing clients.
+	•	Migrations are forward only. Provide backfill jobs when needed.
+
+13. Performance targets
+	•	P95 API read under 300 ms at gateway.
+	•	Ingest a 10 page PDF to first note under 90 seconds.
+	•	Reminder enqueue under 1 second after due window check.
+
+14. Error model
+
+HTTP error
+
+{
+  "error": {
+    "code": "string",
+    "message": "human readable",
+    "details": { "field": "info" },
+    "request_id": "uuid"
+  }
+}
+
+Common codes
+	•	UNAUTHENTICATED
+	•	FORBIDDEN
+	•	NOT_FOUND
+	•	INVALID_ARGUMENT
+	•	CONFLICT
+	•	RATE_LIMITED
+	•	INTERNAL
+
+15. Delivery rules for the AI agent
+	•	Create a branch per task. Use phaseX/.
+	•	Open a PR that lists:
+	•	what changed
+	•	why it changed
+	•	how it was tested
+	•	results and logs or screenshots
+	•	I will review and merge to main.
+
+16. Runbook snippets
+
+Reprocess a document
+	•	Publish ingest.request with the same doc_id. Workers are idempotent.
+
+Reset a stuck consumer
+	•	XAUTOCLAIM messages older than N seconds to a fresh consumer.
+
+Rotate a secret
+	•	Update env and restart affected service. Sessions are rotated on next login.
+
+Purge old logs
+	•	Delete from logs where ts < now minus interval ‘90 days’.

--- a/docs/backend/PRODUCT.md
+++ b/docs/backend/PRODUCT.md
@@ -1,0 +1,274 @@
+# Backend Product Doc
+
+## Purpose
+Build a compliant learning backend that ingests class content, generates study aids, and helps students stay on top of assignments. Keep students in control. Never auto submit work. Integrate with Canvas for context.
+
+## Outcomes
+- Less friction getting course materials into the app
+- Faster understanding of lectures and readings
+- Clear assignment awareness and reminders
+- A backend that is modular, testable, and replaceable
+
+## Target users
+- Students who use Canvas and want summaries, slides, flashcards, and videos
+- Builders of the frontend who need clean contracts and reliable services
+- Operators who need logs, metrics, and safe deploys
+
+## Success metrics
+- Ingestion success rate above 98 percent across PDF, DOCX, PPTX
+- Time to first note under 90 seconds for a 10 page PDF
+- Reminder delivery success above 99 percent
+- Error budget respected. P95 API latency under 300 ms for read endpoints
+
+## Guardrails and compliance
+- No auto submission to Canvas
+- AI output is advisory. Students review and submit themselves
+- Respect Canvas API terms
+- Store secrets in env files. Docker compose wires them in
+- GDPR style data handling. Delete on request. Encrypt tokens at rest
+
+## Scope
+- Pull courses, assignments, and files from Canvas
+- Ingest files into Markdown plus JSON with media references
+- Generate notes, slides, flashcards, and video scripts
+- Create narrated MP4s from scripts and media
+- Serve search across notes with embeddings
+- Send reminders for due items
+- Provide clean APIs to the React app
+
+## Out of scope
+- Grading
+- Plagiarism detection
+- Auto submission to LMS
+- Proctoring
+
+---
+
+## Service map
+
+Each service is small, typed, and replaceable. Any service can be rewritten in another language if it keeps the contract.
+
+- API Gateway. Node TypeScript. Front door for the web app. Auth check. Request routing. No business logic.
+- Auth Service. Node TypeScript. Email plus password. Google OAuth. Single student per school email. Sessions via cookies or JWT.
+- Canvas Service. Node TypeScript. OAuth to Canvas. Sync courses, assignments, module items. Emits ingestion jobs.
+- Ingestion Service. Python. Normalize files. Extract text, images, audio, video. Output Markdown plus JSON. Store media in Azure Blob.
+- AI Service. Python. Summaries. Slides. Flashcards. Video scripts. Uses LLM APIs. Deterministic schemas.
+- Media Service. Python first. Optional Rust core later. TTS and ffmpeg. Build MP4 and audio. Store in Blob.
+- Notification Service. Node TypeScript. Sends email or push reminders for due items.
+- Logging Service. Go or Rust. Collects structured logs. Writes to Postgres.
+
+Shared infra
+- Database. Neon Postgres. No ORM. Migrations folder is the source of truth
+- Storage. Azure Blob Storage
+- Queue. Redis Streams
+- Search embeddings. Redis plus RediSearch
+
+---
+
+## High level flows
+
+### First connect
+1. Student signs up with Google or email and password
+2. Student connects Canvas
+3. Canvas Service syncs courses, assignments, and file metadata to Postgres
+4. Canvas Service enqueues ingestion tasks for new files
+
+### Ingest to study aids
+1. Ingestion Service downloads a file, converts to Markdown plus JSON, extracts media
+2. Writes outputs to Blob and metadata to Postgres
+3. Emits AI tasks
+4. AI Service generates notes, slides, flashcards, and a script
+5. Media Service turns script plus media into MP4
+6. API Gateway returns links and data to the frontend
+
+### Reminders
+1. Notification Service reads assignments and due dates
+2. Schedules and sends reminders
+
+---
+
+## Data contracts
+
+Keep payloads small and explicit. Examples are trimmed.
+
+### Events on Redis Streams
+- `ingest.request`  
+  - `user_id` string  
+  - `source` canvas or upload  
+  - `file_id` string  
+  - `file_url` string
+- `ai.request`  
+  - `user_id` string  
+  - `doc_id` string  
+  - `markdown_url` string  
+  - `json_url` string
+- `media.request`  
+  - `user_id` string  
+  - `doc_id` string  
+  - `script` string  
+  - `assets` array of blob urls
+
+### Ingestion JSON output
+```json
+{
+  "title": "Week 3 Lecture",
+  "sections": [
+    {
+      "heading": "Intro to Graphs",
+      "text": "A graph is ...",
+      "media": [
+        { "type": "image", "url": "blob://image1.png" },
+        { "type": "video", "url": "blob://clip1.mp4" }
+      ],
+      "source": { "kind": "pptx", "page": 3 }
+    }
+  ]
+}
+AI outputs
+	•	Notes markdown url
+	•	Slides markdown url for reveal.js
+	•	Flashcards JSON
+	•	q string
+	•	a string
+	•	hint optional string
+	•	Video script string plus timing hints
+
+⸻
+
+API surfaces
+
+Keep endpoints small and orthogonal. The gateway proxies to services.
+	•	Auth
+	•	POST /auth/signup
+	•	POST /auth/login
+	•	GET /auth/oauth/google/start
+	•	GET /auth/oauth/google/callback
+	•	POST /auth/logout
+	•	Canvas
+	•	POST /canvas/connect
+	•	POST /canvas/sync
+	•	GET /canvas/courses
+	•	GET /canvas/assignments
+	•	Ingestion
+	•	POST /ingestion/start
+	•	GET /documents/:id
+	•	AI
+	•	POST /ai/start
+	•	GET /notes/:doc_id
+	•	GET /flashcards/:doc_id
+	•	Media
+	•	POST /media/start
+	•	GET /media/:doc_id
+	•	Search
+	•	GET /search?q=...
+	•	Health
+	•	GET /health
+
+All endpoints require session cookies except health.
+
+⸻
+
+Database plan
+
+Neon Postgres. No ORM. Migrations per service. JSONB where flexible.
+
+Core tables
+	•	users id, school_email unique, password_hash, google_id unique, canvas_user_id unique, created_at
+	•	sessions id, user_id, token, expires_at
+	•	canvas_courses id, user_id, canvas_course_id, name, term, start_date, end_date
+	•	canvas_assignments id, course_id, canvas_assignment_id, title, due_at, status
+	•	documents id, user_id, course_id, title, kind, blob_url, markdown_url, json_url, created_at
+	•	notes id, doc_id, markdown_url, jsonb summary, created_at
+	•	flashcards id, doc_id, jsonb cards
+	•	media_assets id, doc_id, kind, blob_url, thumbnail_url
+	•	logs id, ts, service, level, message, jsonb context
+
+Add indexes on foreign keys and common filters like due_at.
+
+⸻
+
+Storage plan
+	•	Azure Blob containers by service
+	•	raw original uploads or Canvas fetches
+	•	derived markdown and json
+	•	media images, audio, videos
+	•	Use signed urls server side. Clients never see account keys
+
+⸻
+
+Non functionals
+	•	Reliability
+	•	Idempotent ingestion. Safe reprocessing by doc id
+	•	At least once delivery on streams. Handlers are idempotent
+	•	Performance
+	•	Stream large files to Blob
+	•	Bounded concurrency per worker
+	•	Security
+	•	Encrypt Canvas tokens
+	•	Rotate session on login
+	•	Rate limit auth and sync routes
+	•	Observability
+	•	Structured logs in Postgres
+	•	Request ids across services
+	•	Health checks per service
+
+⸻
+
+Testing plan
+	•	Unit tests
+	•	Repos and adapters use fakes. No network in unit tests
+	•	Contract tests
+	•	API Gateway against service mocks
+	•	Message schemas validated on publish and consume
+	•	Integration tests
+	•	docker compose up a stack with Postgres and Redis
+	•	MSW or Prism mock for Canvas
+	•	Fixtures
+	•	Sample PDF, DOCX, PPTX in a test assets bucket
+	•	CI gates
+	•	Lint, type check, unit, contract, integration
+
+⸻
+
+Delivery rules for the AI agent
+	•	Create a branch per task. Use phaseX/<task-name>
+	•	Open a PR with
+	•	What changed
+	•	Why it changed
+	•	How it was tested
+	•	Results and logs or screenshots
+	•	I will review and merge to main
+
+⸻
+
+Phasing
+	•	Phase 1. Auth Service and API Gateway ready with health checks
+	•	Phase 2. Canvas connect and sync with fixtures
+	•	Phase 3. Ingestion for PDF, DOCX, PPTX to Markdown plus JSON
+	•	Phase 4. AI summaries, slides, and flashcards with mocked LLM
+	•	Phase 5. Media MP4 basics with TTS and a title card
+	•	Phase 6. Reminders from assignments
+	•	Phase 7. Logs and dashboards
+
+⸻
+
+Risks and mitigations
+	•	Canvas payload variance. Use defensive parsing and fixtures
+	•	Legacy formats. Convert to modern formats with LibreOffice headless
+	•	Large media. Stream, do not buffer in memory
+	•	Vendor limits. Backoff and retries. Queue at the edge of each service
+
+⸻
+
+Open questions
+	•	Preferred push channel for reminders. Email or push
+	•	Choice of TTS provider
+	•	Exact retention policy for blobs and logs
+
+⸻
+
+Glossary
+	•	Markdown. Human readable text for notes and slides
+	•	JSON structure. Machine friendly sections and media map
+	•	Blob. File in Azure Blob Storage
+	•	Idempotent. Safe to run multiple times with the same input

--- a/docs/backend/engineering.json
+++ b/docs/backend/engineering.json
@@ -1,0 +1,472 @@
+{
+  "backend_technical": {
+    "principles": [
+      "Microservices are replaceable and testable",
+      "No ORM, raw SQL with migrations",
+      "Files target 100 lines, split aggressively",
+      "Strict typing and explicit contracts",
+      "All externals behind adapters with fakes for tests",
+      "Config from env, wired through docker compose",
+      "Aliases use @ for imports where supported"
+    ],
+    "stack": {
+      "languages": {
+        "api_gateway": "Node TypeScript",
+        "auth_service": "Node TypeScript",
+        "canvas_service": "Node TypeScript",
+        "ingestion_service": "Python",
+        "ai_service": "Python",
+        "media_service": "Python",
+        "notification_service": "Node TypeScript",
+        "logging_service": "Go or Rust"
+      },
+      "infra": {
+        "database": "Neon Postgres",
+        "storage": "Azure Blob Storage",
+        "queue": "Redis Streams",
+        "search": "RediSearch optional"
+      },
+      "ports": {
+        "api_gateway": 3001,
+        "auth": 4001,
+        "canvas": 4002,
+        "ingestion": 4003,
+        "ai": 4004,
+        "media": 4005,
+        "notification": 4006,
+        "logging": 4010
+      }
+    },
+    "repo_layout": {
+      "root": [
+        "services/* per microservice",
+        "packages/backend-configs for shared lint and tsconfig and py configs",
+        "packages/backend-shared for small cross service utils",
+        "infra/docker-compose.yml and local dev deps",
+        "migrations/<bounded_context>/*.sql",
+        "docs/backend/*.md"
+      ],
+      "service_folder": [
+        "src/app http handlers or cli",
+        "src/domain use cases and pure logic",
+        "src/infra adapters db and blob and queue and http",
+        "src/contracts request and response types and validators",
+        "src/tests unit and contract"
+      ]
+    },
+    "env": {
+      "global": ["POSTGRES_URL", "REDIS_URL", "AZURE_STORAGE_CONNECTION_STRING", "LOG_LEVEL"],
+      "auth": ["JWT_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+      "canvas": ["CANVAS_BASE_URL", "CANVAS_CLIENT_ID", "CANVAS_CLIENT_SECRET"],
+      "ai": ["OPENAI_API_KEY"],
+      "media": ["TTS_PROVIDER", "ELEVENLABS_API_KEY", "AWS_POLLY_REGION", "FFMPEG_PATH"],
+      "notification": ["SMTP_HOST", "SMTP_USER", "SMTP_PASS"]
+    },
+    "database": {
+      "rules": [
+        "One migration folder per bounded context",
+        "Use UUID v4 ids",
+        "Add explicit indexes",
+        "Prefer JSONB for flexible AI payloads"
+      ],
+      "tables": [
+        {
+          "name": "users",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "school_email", "type": "text unique not null"},
+            {"name": "password_hash", "type": "text"},
+            {"name": "google_id", "type": "text unique"},
+            {"name": "canvas_user_id", "type": "text unique"},
+            {"name": "created_at", "type": "timestamp default now()"},
+            {"name": "updated_at", "type": "timestamp default now()"}
+          ]
+        },
+        {
+          "name": "sessions",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "user_id", "type": "uuid references users(id) on delete cascade"},
+            {"name": "token", "type": "text unique not null"},
+            {"name": "expires_at", "type": "timestamp not null"},
+            {"name": "created_at", "type": "timestamp default now()"}
+          ],
+          "indexes": ["user_id"]
+        },
+        {
+          "name": "canvas_courses",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "user_id", "type": "uuid references users(id) on delete cascade"},
+            {"name": "canvas_course_id", "type": "text"},
+            {"name": "name", "type": "text"},
+            {"name": "term", "type": "text"},
+            {"name": "start_date", "type": "date"},
+            {"name": "end_date", "type": "date"}
+          ],
+          "indexes": ["user_id"]
+        },
+        {
+          "name": "canvas_assignments",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "course_id", "type": "uuid references canvas_courses(id) on delete cascade"},
+            {"name": "canvas_assignment_id", "type": "text"},
+            {"name": "title", "type": "text"},
+            {"name": "due_at", "type": "timestamp"},
+            {"name": "status", "type": "text"}
+          ],
+          "indexes": ["course_id", "due_at"]
+        },
+        {
+          "name": "documents",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "user_id", "type": "uuid references users(id) on delete cascade"},
+            {"name": "course_id", "type": "uuid references canvas_courses(id)"},
+            {"name": "title", "type": "text"},
+            {"name": "kind", "type": "text"},
+            {"name": "blob_url", "type": "text"},
+            {"name": "markdown_url", "type": "text"},
+            {"name": "json_url", "type": "text"},
+            {"name": "created_at", "type": "timestamp default now()"}
+          ],
+          "indexes": ["user_id"]
+        },
+        {
+          "name": "notes",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "doc_id", "type": "uuid references documents(id) on delete cascade"},
+            {"name": "markdown_url", "type": "text"},
+            {"name": "summary", "type": "jsonb"},
+            {"name": "created_at", "type": "timestamp default now()"}
+          ],
+          "indexes": ["doc_id"]
+        },
+        {
+          "name": "flashcards",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "doc_id", "type": "uuid references documents(id) on delete cascade"},
+            {"name": "cards", "type": "jsonb"}
+          ],
+          "indexes": ["doc_id"]
+        },
+        {
+          "name": "media_assets",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "doc_id", "type": "uuid references documents(id) on delete cascade"},
+            {"name": "kind", "type": "text"},
+            {"name": "blob_url", "type": "text"},
+            {"name": "thumbnail_url", "type": "text"}
+          ],
+          "indexes": ["doc_id"]
+        },
+        {
+          "name": "logs",
+          "columns": [
+            {"name": "id", "type": "uuid primary key"},
+            {"name": "ts", "type": "timestamp default now()"},
+            {"name": "service", "type": "text"},
+            {"name": "level", "type": "text"},
+            {"name": "message", "type": "text"},
+            {"name": "context", "type": "jsonb"}
+          ],
+          "indexes": ["ts"]
+        }
+      ]
+    },
+    "storage": {
+      "containers": ["raw", "derived", "media"],
+      "paths": {
+        "raw": "raw/{user_id}/{doc_id}/{original_filename}",
+        "derived_md": "derived/{user_id}/{doc_id}/{artifact}.md",
+        "derived_json": "derived/{user_id}/{doc_id}/structure.json",
+        "media": "media/{user_id}/{doc_id}/{asset_id}.{ext}",
+        "thumb": "media/{user_id}/{doc_id}/thumb_{asset_id}.jpg"
+      },
+      "access": [
+        "Services request short lived SAS for read or write",
+        "Clients receive signed urls only"
+      ]
+    },
+    "messaging": {
+      "streams": [
+        "ingest.request",
+        "ingest.result",
+        "ai.request",
+        "ai.result",
+        "media.request",
+        "media.result",
+        "notify.request"
+      ],
+      "consumer_groups": {
+        "ingestion": "ingestion:group",
+        "ai": "ai:group",
+        "media": "media:group",
+        "notify": "notify:group"
+      },
+      "contracts": {
+        "ingest.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "source": "canvas or upload",
+          "file_url": "blob url",
+          "kind": "pdf or docx or pptx"
+        },
+        "ai.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "markdown_url": "blob url",
+          "json_url": "blob url"
+        },
+        "media.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "script": "string",
+          "assets": ["blob url"]
+        }
+      },
+      "idempotency": [
+        "Use doc_id as natural id",
+        "Upsert by doc_id in workers"
+      ],
+      "retry": [
+        "Use XCLAIM after visibility timeout",
+        "Dead letter per stream after N failures"
+      ]
+    },
+    "services": [
+      {
+        "name": "API Gateway",
+        "language": "Node TypeScript",
+        "port": 3001,
+        "responsibilities": [
+          "Session check with Auth Service",
+          "Proxy and small aggregation",
+          "Rate limit and request id"
+        ],
+        "headers_out": ["X-Request-Id", "X-User-Id", "X-Service-Token"],
+        "routes": [
+          {"method": "GET", "path": "/health", "auth": false},
+          {"method": "ANY", "path": "/auth/*", "auth": false},
+          {"method": "ANY", "path": "/canvas/*", "auth": true},
+          {"method": "ANY", "path": "/ingestion/*", "auth": true},
+          {"method": "ANY", "path": "/ai/*", "auth": true},
+          {"method": "ANY", "path": "/media/*", "auth": true},
+          {"method": "ANY", "path": "/notify/*", "auth": true},
+          {"method": "GET", "path": "/search", "auth": true}
+        ]
+      },
+      {
+        "name": "Auth Service",
+        "language": "Node TypeScript",
+        "port": 4001,
+        "routes": [
+          {"method": "POST", "path": "/auth/signup"},
+          {"method": "POST", "path": "/auth/login"},
+          {"method": "GET", "path": "/auth/oauth/google/start"},
+          {"method": "GET", "path": "/auth/oauth/google/callback"},
+          {"method": "POST", "path": "/auth/logout"},
+          {"method": "GET", "path": "/auth/session"}
+        ],
+        "security": [
+          "Argon2id password hashing",
+          "HttpOnly cookie sessions",
+          "Lockout and rate limit on failures"
+        ]
+      },
+      {
+        "name": "Canvas Service",
+        "language": "Node TypeScript",
+        "port": 4002,
+        "routes": [
+          {"method": "POST", "path": "/canvas/connect"},
+          {"method": "POST", "path": "/canvas/sync"},
+          {"method": "GET", "path": "/canvas/courses"},
+          {"method": "GET", "path": "/canvas/assignments"}
+        ],
+        "behavior": [
+          "OAuth2 to Canvas, store tokens encrypted",
+          "Sync courses and assignments and module items",
+          "Emit ingest.request for new files"
+        ]
+      },
+      {
+        "name": "Ingestion Service",
+        "language": "Python",
+        "port": 4003,
+        "routes": [
+          {"method": "POST", "path": "/ingestion/start"},
+          {"method": "GET", "path": "/documents/:id"}
+        ],
+        "workers": [
+          "Normalize legacy formats with LibreOffice headless",
+          "Extract text and media",
+          "Write markdown and structure json to Blob",
+          "Upsert documents row"
+        ],
+        "json_shape_example": {
+          "title": "string",
+          "sections": [
+            {
+              "heading": "string",
+              "text": "string",
+              "media": [{"type": "image or audio or video", "url": "blob url", "alt": "optional"}],
+              "source": {"kind": "pdf or docx or pptx", "page": 3}
+            }
+          ]
+        }
+      },
+      {
+        "name": "AI Service",
+        "language": "Python",
+        "port": 4004,
+        "routes": [
+          {"method": "POST", "path": "/ai/start"},
+          {"method": "GET", "path": "/notes/:doc_id"},
+          {"method": "GET", "path": "/flashcards/:doc_id"}
+        ],
+        "workers": [
+          "Generate summaries to notes.summary jsonb and markdown_url",
+          "Generate slides markdown",
+          "Generate flashcards jsonb"
+        ],
+        "validation": ["Validate prompt outputs to deterministic schemas"]
+      },
+      {
+        "name": "Media Service",
+        "language": "Python",
+        "port": 4005,
+        "routes": [
+          {"method": "POST", "path": "/media/start"},
+          {"method": "GET", "path": "/media/:doc_id"}
+        ],
+        "workers": [
+          "TTS via provider adapter",
+          "Compose video with ffmpeg",
+          "Store mp4 and thumbnail"
+        ]
+      },
+      {
+        "name": "Notification Service",
+        "language": "Node TypeScript",
+        "port": 4006,
+        "routes": [
+          {"method": "POST", "path": "/notify/test"},
+          {"method": "POST", "path": "/notify/schedule"},
+          {"method": "GET", "path": "/notify/status/:id"}
+        ],
+        "workers": [
+          "Read assignments due_at",
+          "Schedule reminders",
+          "Send via SMTP or push provider"
+        ]
+      },
+      {
+        "name": "Logging Service",
+        "language": "Go or Rust",
+        "port": 4010,
+        "routes": [
+          {"method": "POST", "path": "/logs"},
+          {"method": "GET", "path": "/logs/query"}
+        ],
+        "storage": ["Insert into logs table", "Consider partitions later"]
+      }
+    ],
+    "security": {
+      "rules": [
+        "Secrets only in env and secret manager",
+        "Encrypt Canvas tokens with AES GCM",
+        "HttpOnly SameSite Lax cookies, Secure in prod",
+        "Validate inbound JSON with zod or pydantic",
+        "Strict CORS at gateway",
+        "Rate limit login and sync and heavy endpoints"
+      ]
+    },
+    "observability": {
+      "log_format_example": {
+        "ts": "2025-01-01T12:34:56Z",
+        "service": "ingestion",
+        "level": "info",
+        "message": "extracted markdown",
+        "context": {"doc_id": "uuid", "duration_ms": 842}
+      },
+      "health": {"route": "/health", "body": {"ok": true, "uptime_ms": "<number>", "version": "<semver>"}}
+    },
+    "testing": {
+      "unit": [
+        "Domain and adapters use fakes for db and blob and queue and http",
+        "No network in unit tests"
+      ],
+      "contract": [
+        "Validate request and response shapes per endpoint",
+        "Validate stream messages on publish and consume"
+      ],
+      "integration": [
+        "Compose up Postgres and Redis and Azurite",
+        "Start a subset of services and run end to end",
+        "Mock Canvas with fixtures or a stub server"
+      ],
+      "fixtures": ["Sample PDF and DOCX and PPTX in test assets"],
+      "ci": ["Lint and type check and unit and contract and integration", "Build images and optional smoke compose up"]
+    },
+    "versioning": {
+      "http_prefix": "/v1",
+      "compat": ["Add fields in a backward compatible way", "Forward only migrations and backfill jobs if needed"]
+    },
+    "codegen": {
+      "backend_to_frontend": [
+        "API Gateway serves OpenAPI at /openapi.json",
+        "Script generates typed clients and route constants for frontend"
+      ]
+    },
+    "performance_targets": {
+      "api_p95_ms": 300,
+      "first_note_for_10_page_pdf_sec": 90,
+      "reminder_enqueue_sec": 1
+    },
+    "error_model": {
+      "shape": {
+        "error": {
+          "code": "string",
+          "message": "human readable",
+          "details": {"field": "info"},
+          "request_id": "uuid"
+        }
+      },
+      "codes": ["UNAUTHENTICATED", "FORBIDDEN", "NOT_FOUND", "INVALID_ARGUMENT", "CONFLICT", "RATE_LIMITED", "INTERNAL"]
+    },
+    "delivery_rules_for_ai_agent": {
+      "branching": "Create branch per task phaseX/task-name",
+      "pull_request": [
+        "What changed",
+        "Why it changed",
+        "How it was tested",
+        "Results and logs or screenshots"
+      ]
+    },
+    "phasing": [
+      "Phase 1 Auth and Gateway with health",
+      "Phase 2 Canvas connect and sync",
+      "Phase 3 Ingestion PDF and DOCX and PPTX to markdown plus json",
+      "Phase 4 AI summaries and slides and flashcards with mocked LLM",
+      "Phase 5 Media MP4 basics",
+      "Phase 6 Reminders",
+      "Phase 7 Logs and dashboards"
+    ],
+    "runbook": {
+      "reprocess_document": ["Publish ingest.request with same doc_id", "Workers are idempotent"],
+      "reset_consumer": ["XAUTOCLAIM older than timeout to a fresh consumer"],
+      "rotate_secret": ["Update env and restart service", "Rotate sessions on next login"],
+      "purge_old_logs": ["Delete from logs where ts older than 90 days"]
+    },
+    "guardrails": [
+      "No auto submission to Canvas",
+      "AI outputs are advisory",
+      "Respect Canvas API terms"
+    ]
+  }
+}

--- a/docs/backend/product.json
+++ b/docs/backend/product.json
@@ -1,0 +1,305 @@
+Here’s a structured JSON version of the backend product doc for your AI to consume.
+
+{
+  "backend_product": {
+    "purpose": "Provide a compliant learning backend that ingests course content, generates study aids, integrates with Canvas, and keeps students in control of submissions.",
+    "outcomes": [
+      "Frictionless import of course materials",
+      "Faster understanding via notes, slides, flashcards, and videos",
+      "Clear awareness of assignments and due dates",
+      "Modular, testable, replaceable services"
+    ],
+    "target_users": [
+      "Students using Canvas who want summaries, slides, flashcards, and videos",
+      "Frontend engineers who need clean contracts",
+      "Operators who need logs and safe deploys"
+    ],
+    "success_metrics": {
+      "ingestion_success_rate_pct": 98,
+      "time_to_first_note_sec_for_10_page_pdf": 90,
+      "reminder_delivery_success_pct": 99,
+      "api_read_p95_ms": 300
+    },
+    "guardrails_compliance": [
+      "No auto submission to Canvas",
+      "AI output is advisory and reviewed by the student",
+      "Respect Canvas API terms",
+      "Secrets only in env files linked via docker compose",
+      "Support deletion on request and encrypt tokens at rest"
+    ],
+    "scope": [
+      "Sync courses, assignments, and files from Canvas",
+      "Ingest files into Markdown plus structured JSON with media references",
+      "Generate notes, slides, flashcards, and video scripts",
+      "Render narrated MP4s from scripts and media",
+      "Expose semantic search over notes",
+      "Send reminders for due items",
+      "Serve clean APIs to the React app"
+    ],
+    "out_of_scope": [
+      "Grading",
+      "Plagiarism detection",
+      "Auto submission to LMS",
+      "Proctoring"
+    ],
+    "services": [
+      {
+        "name": "API Gateway",
+        "language": "Node TypeScript",
+        "role": "Front door for web app, auth check, proxy, small aggregation"
+      },
+      {
+        "name": "Auth Service",
+        "language": "Node TypeScript",
+        "role": "Email plus password, Google OAuth, single student per school email, sessions"
+      },
+      {
+        "name": "Canvas Service",
+        "language": "Node TypeScript",
+        "role": "Canvas OAuth, sync courses and assignments and module items, enqueue ingestion"
+      },
+      {
+        "name": "Ingestion Service",
+        "language": "Python",
+        "role": "Extract text and media, normalize to Markdown plus JSON, store to Blob"
+      },
+      {
+        "name": "AI Service",
+        "language": "Python",
+        "role": "Generate summaries, slides, flashcards, and video scripts"
+      },
+      {
+        "name": "Media Service",
+        "language": "Python, optional Rust core later",
+        "role": "TTS plus ffmpeg to produce MP4 and audio, store to Blob"
+      },
+      {
+        "name": "Notification Service",
+        "language": "Node TypeScript",
+        "role": "Send reminders for assignments"
+      },
+      {
+        "name": "Logging Service",
+        "language": "Go or Rust",
+        "role": "Collect structured logs and store in Postgres"
+      }
+    ],
+    "infra": {
+      "database": "Neon Postgres",
+      "storage": "Azure Blob Storage",
+      "queue": "Redis Streams",
+      "search_embeddings": "Redis with RediSearch"
+    },
+    "high_level_flows": [
+      {
+        "name": "First connect",
+        "steps": [
+          "Student signs up and logs in",
+          "Student connects Canvas",
+          "Canvas Service syncs courses, assignments, and files to Postgres",
+          "New files enqueue ingestion tasks"
+        ]
+      },
+      {
+        "name": "Ingest to study aids",
+        "steps": [
+          "Ingestion downloads file, outputs Markdown and JSON, stores media",
+          "AI generates notes, slides, flashcards, and script",
+          "Media composes MP4 from script and assets",
+          "API returns links and data to frontend"
+        ]
+      },
+      {
+        "name": "Reminders",
+        "steps": [
+          "Notification reads assignments and due dates",
+          "Schedules and sends reminders"
+        ]
+      }
+    ],
+    "data_contracts": {
+      "streams": {
+        "ingest.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "source": "canvas or upload",
+          "file_url": "blob url",
+          "kind": "pdf or docx or pptx"
+        },
+        "ai.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "markdown_url": "blob url",
+          "json_url": "blob url"
+        },
+        "media.request": {
+          "user_id": "uuid",
+          "doc_id": "uuid",
+          "script": "string",
+          "assets": ["blob url"]
+        }
+      },
+      "ingestion_json_example": {
+        "title": "Week 3 Lecture",
+        "sections": [
+          {
+            "heading": "Intro to Graphs",
+            "text": "A graph is ...",
+            "media": [
+              { "type": "image", "url": "blob://image1.png" },
+              { "type": "video", "url": "blob://clip1.mp4" }
+            ],
+            "source": { "kind": "pptx", "page": 3 }
+          }
+        ]
+      },
+      "ai_outputs": {
+        "notes_markdown_url": "blob url",
+        "slides_markdown_url": "blob url",
+        "flashcards": [{ "q": "string", "a": "string", "hint": "optional string" }],
+        "video_script": "string with timing hints"
+      }
+    },
+    "api_surfaces": {
+      "auth": [
+        { "method": "POST", "path": "/auth/signup" },
+        { "method": "POST", "path": "/auth/login" },
+        { "method": "GET", "path": "/auth/oauth/google/start" },
+        { "method": "GET", "path": "/auth/oauth/google/callback" },
+        { "method": "POST", "path": "/auth/logout" }
+      ],
+      "canvas": [
+        { "method": "POST", "path": "/canvas/connect" },
+        { "method": "POST", "path": "/canvas/sync" },
+        { "method": "GET", "path": "/canvas/courses" },
+        { "method": "GET", "path": "/canvas/assignments" }
+      ],
+      "ingestion": [
+        { "method": "POST", "path": "/ingestion/start" },
+        { "method": "GET", "path": "/documents/:id" }
+      ],
+      "ai": [
+        { "method": "POST", "path": "/ai/start" },
+        { "method": "GET", "path": "/notes/:doc_id" },
+        { "method": "GET", "path": "/flashcards/:doc_id" }
+      ],
+      "media": [
+        { "method": "POST", "path": "/media/start" },
+        { "method": "GET", "path": "/media/:doc_id" }
+      ],
+      "search": [
+        { "method": "GET", "path": "/search" }
+      ],
+      "health": [
+        { "method": "GET", "path": "/health" }
+      ]
+    },
+    "database_plan": {
+      "no_orm": true,
+      "migrations_by_service": true,
+      "core_tables": [
+        "users",
+        "sessions",
+        "canvas_courses",
+        "canvas_assignments",
+        "documents",
+        "notes",
+        "flashcards",
+        "media_assets",
+        "logs"
+      ]
+    },
+    "storage_plan": {
+      "containers": ["raw", "derived", "media"],
+      "client_access": "signed urls only",
+      "paths": {
+        "raw": "raw/{user_id}/{doc_id}/{original_filename}",
+        "derived_md": "derived/{user_id}/{doc_id}/{artifact}.md",
+        "derived_json": "derived/{user_id}/{doc_id}/structure.json",
+        "media": "media/{user_id}/{doc_id}/{asset_id}.{ext}"
+      }
+    },
+    "non_functionals": {
+      "reliability": [
+        "Idempotent ingestion by doc_id",
+        "At least once delivery with idempotent handlers"
+      ],
+      "performance": [
+        "Stream large files to Blob",
+        "Bounded worker concurrency"
+      ],
+      "security": [
+        "Encrypt Canvas tokens",
+        "Rotate session on login",
+        "Rate limit sensitive routes"
+      ],
+      "observability": [
+        "Structured logs in Postgres",
+        "Request ids across services",
+        "Per service health endpoints"
+      ]
+    },
+    "testing_plan": {
+      "unit": [
+        "Pure domain logic",
+        "Adapters with fakes for db, blob, queue, http"
+      ],
+      "contract": [
+        "Validate endpoint request and response shapes",
+        "Validate stream message shapes on publish and consume"
+      ],
+      "integration": [
+        "Compose Postgres, Redis, Azurite",
+        "Run end to end with Canvas fixtures"
+      ],
+      "fixtures": [
+        "Sample PDF",
+        "Sample DOCX",
+        "Sample PPTX"
+      ],
+      "ci_gates": [
+        "Lint",
+        "Type check",
+        "Unit tests",
+        "Contract tests",
+        "Integration tests"
+      ]
+    },
+    "delivery_rules_for_ai_agent": {
+      "branch_per_task": true,
+      "branch_naming": "phaseX/task-name",
+      "pull_request_template": [
+        "What changed",
+        "Why it changed",
+        "How it was tested",
+        "Results with logs or screenshots"
+      ]
+    },
+    "phasing": [
+      "Phase 1 Auth and Gateway with health",
+      "Phase 2 Canvas connect and sync",
+      "Phase 3 Ingestion for PDF DOCX PPTX",
+      "Phase 4 AI summaries and slides and flashcards",
+      "Phase 5 Media MP4 basics",
+      "Phase 6 Reminders",
+      "Phase 7 Logs and dashboards"
+    ],
+    "risks_and_mitigations": [
+      "Canvas payload variance handled by defensive parsing and fixtures",
+      "Legacy formats handled by LibreOffice headless conversion",
+      "Large media handled by streaming not buffering",
+      "Vendor limits handled by backoff and retries, queues at service edges"
+    ],
+    "open_questions": [
+      "Preferred channel for reminders, email or push",
+      "TTS provider choice",
+      "Retention policy for blobs and logs"
+    ],
+    "glossary": {
+      "Markdown": "Human readable text for notes and slides",
+      "JSON structure": "Machine friendly sections and media map",
+      "Blob": "File stored in Azure Blob Storage",
+      "Idempotent": "Safe to run multiple times with the same input"
+    }
+  }
+}

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,0 +1,17 @@
+# Frontend docs overview
+
+Goal: give the AI exact rules and contracts to build the React app with Vite, React Router, styled-components, react-query, and our custom UI library.
+
+Read order:
+1) principles.md
+2) project-structure.md
+3) routing.md
+4) ui-library.md
+5) styling-theming.md
+6) data-access.md
+7) state-hooks.md
+8) constants.md
+9) linting.md
+10) testing.md
+11) codegen-sync.md
+12) checklists.md

--- a/docs/frontend/checklists.md
+++ b/docs/frontend/checklists.md
@@ -1,0 +1,25 @@
+# Checklists
+
+Add a new Area
+- create `src/Areas/<Area>/index.tsx`
+- create `src/Areas/<Area>/<Area>.routes.tsx`
+- add components, hooks, constants folders as needed
+- add route object in `src/app/routes.ts`
+- update tests
+
+Add a new page
+- create page component in Area
+- add a new route object in `src/app/routes.ts`
+- if params exist, list them in `params` and use `buildPath`
+
+Call an API
+- add or import RouteDef from `packages/talvra-routes`
+- create a hook in Area that calls `useAPI`
+- render in a page using UI primitives
+
+PR rules for the AI agent
+- create a branch named `frontend/<feature>`
+- describe what changed and why
+- list how it was tested
+- include before and after screenshots if UI changed
+- ensure lint and tests pass

--- a/docs/frontend/codegen-sync.md
+++ b/docs/frontend/codegen-sync.md
@@ -1,0 +1,15 @@
+# Codegen and sync
+
+Goal
+- Keep frontend API route constants and types in sync with backend.
+
+Plan
+- Backend exposes OpenAPI spec.
+- Script generates:
+  - typed clients, request and response types into `packages/talvra-api`.
+  - API route constants into `packages/talvra-routes`.
+- Add `pnpm run codegen` to run in CI and on postinstall.
+
+Frontend routes
+- Frontend routes live in `src/app/routes.ts`.
+- When adding a new page, add it to this file only and commit.

--- a/docs/frontend/constants.md
+++ b/docs/frontend/constants.md
@@ -1,0 +1,15 @@
+# Constants
+
+Shared constants
+- `packages/talvra-constants` for theme, sizes, enums.
+
+Frontend route constants
+- `src/app/routes.ts` holds FRONT_ROUTES.
+
+Backend route constants
+- `packages/talvra-routes` holds API endpoints.
+- Keep in sync through codegen. See codegen-sync.md.
+
+Import style
+- Use aliases `@`, `@ui`, `@hooks`, `@constants`, `@routes`, `@api`.
+- No deep relative imports.

--- a/docs/frontend/data-access.md
+++ b/docs/frontend/data-access.md
@@ -1,0 +1,36 @@
+# Data access
+
+Library: @tanstack/react-query
+
+Abstraction: `useAPI` in `packages/talvra-api`
+
+API routes
+- `packages/talvra-routes` exports `RouteDef` objects.
+- `useAPI` takes a route constant, optional query and body.
+- Returns `{ data, isLoading, isError, error, run }`.
+
+Contract
+```ts
+type RouteDef = {
+  endpoint: string;
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  auth?: boolean;
+  description?: string;
+};
+
+export function useAPI<TResp = unknown, TBody = unknown>(opts: {
+  route: RouteDef;
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: TBody;
+  enabled?: boolean;
+}): {
+  data: TResp | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null | undefined;
+  run: (payload?: TBody) => Promise<TResp>;
+};
+
+Rules
+- All network access uses useAPI. No direct fetch in pages.
+- Errors and loading states handled uniformly through returned metadata.

--- a/docs/frontend/linting.md
+++ b/docs/frontend/linting.md
@@ -1,0 +1,11 @@
+# Linting and guards
+
+Purpose
+- Enforce no raw HTML tags in pages.
+- Enforce use of route helpers, not string paths.
+
+Rules
+- ESLint override blocks `div`, `span`, `section`, headings, inputs, and list tags in `apps/web/src` except inside `packages/talvra-ui`.
+- ESLint rule warns on literal paths like `/admin` or `/courses` in app code.
+
+Config lives in `packages/configs` and is shared by the web app.

--- a/docs/frontend/principles.md
+++ b/docs/frontend/principles.md
@@ -1,0 +1,12 @@
+# Principles
+
+- Areas based feature layout under `src/Areas`.
+- Pages do not use raw HTML tags. Only custom primitives from `@ui`.
+- UI components are dumb. Business logic and data live in hooks.
+- Heavy typing everywhere. No `any` unless justified and documented.
+- Files target 100 lines max. Break into smaller modules when needed.
+- Shared things only in shared folders. Area specific things live inside the Area.
+- Consistent styling via styled-components and a shared theme.
+- All data fetching goes through `useAPI` on top of react-query.
+- Frontend routes are a single source of truth in `src/app/routes.ts`.
+- API routes are a single source of truth in `packages/talvra-routes`.

--- a/docs/frontend/project-structure.md
+++ b/docs/frontend/project-structure.md
@@ -1,0 +1,43 @@
+# Project structure
+
+Monorepo layout
+
+repo-root/
+apps/
+web/
+src/
+Areas/
+Admin/
+index.tsx
+Admin.routes.tsx
+components/
+hooks/
+constants/
+Courses/
+index.tsx
+Courses.routes.tsx
+components/
+hooks/
+constants/
+components/        # shared only
+hooks/             # shared only
+constants/         # shared only
+app/
+routes.ts
+AppRoutes.tsx
+AppProvider.tsx
+main.tsx
+vite.config.ts
+tsconfig.json
+packages/
+talvra-ui/
+talvra-hooks/
+talvra-constants/
+talvra-routes/
+talvra-api/
+configs/
+
+Rules
+- Area specific components in `Areas/<Area>/components`.
+- Area specific hooks in `Areas/<Area>/hooks`.
+- Promote to shared only when used by more than one Area.

--- a/docs/frontend/routing.md
+++ b/docs/frontend/routing.md
@@ -1,0 +1,84 @@
+# Routing
+
+Library: React Router v6
+
+Single source of truth: `src/app/routes.ts` defines all pages, metadata, and lazy loaders.
+
+Contract
+```ts
+type FrontRoute = {
+  key: string;
+  path: string;
+  area: "admin" | "courses" | "core";
+  title?: string;
+  requiresAuth?: boolean;
+  component: React.LazyExoticComponent<() => JSX.Element>;
+  params?: readonly string[];
+};
+
+export const FRONT_ROUTES: Record<string, FrontRoute> = { ... };
+
+export function buildPath<K extends keyof typeof FRONT_ROUTES>(
+  key: K,
+  params?: Record<string, string | number>,
+  query?: Record<string, string | number | boolean | undefined>
+): string;
+
+Composition
+	•	AppRoutes.tsx renders <Route> items from FRONT_ROUTES.
+	•	Route guards wrap elements when requiresAuth is true.
+	•	Use buildPath or useTalvraNav to navigate. Never hardcode paths.
+
+Code splitting
+	•	Use lazy(() => import("...")) in the route constants.
+
+---
+
+## docs/frontend/ui-library.md
+
+```markdown
+# UI library
+
+Location: `packages/talvra-ui`
+
+Purpose
+- Wrap raw HTML tags with styled-components.
+- Only this package can contain raw tags.
+- Export primitives and patterns.
+
+Primitives
+- `Surface`, `Stack`, `Text`, `Card`, `Button`, `Input`, `Table`, `Link`.
+
+Contract
+```ts
+// pages must import from @ui, not react-dom tags.
+import { Surface, Stack, Text, Card, Button } from "@ui";
+
+Patterns
+	•	Compose only from primitives inside Areas.
+	•	Charts and Area widgets live under that Area and still use primitives.
+
+Accessibility
+	•	Provide focus states, aria labels, and keyboard nav where relevant.
+
+---
+
+## docs/frontend/styling-theming.md
+
+```markdown
+# Styling and theming
+
+Library: styled-components
+
+Theme source: `packages/talvra-constants/src/theme.ts`
+
+Tokens
+- colors, spacing, radius, typography scale.
+
+Rules
+- No Tailwind.
+- Use theme tokens only, no hardcoded colors in pages.
+- Put complex styles inside UI primitives. Pages stay declarative.
+
+Provider
+- `AppProvider.tsx` mounts ThemeProvider and react-query QueryClientProvider.

--- a/docs/frontend/state-hooks.md
+++ b/docs/frontend/state-hooks.md
@@ -1,0 +1,13 @@
+# State and hooks
+
+Rules
+- UI is dumb. Logic sits in hooks.
+- Name hooks with project context. Example: `useTalvraState`, `useTalvraAuth`, `useTalvraCourses`.
+
+Placement
+- Shared hooks in `packages/talvra-hooks`.
+- Area hooks in `Areas/<Area>/hooks`.
+
+Examples
+- `useTalvraCourses` wraps `useAPI(GET_ALL_COURSES)`.
+- `useTalvraAuth` exposes `user`, `signIn`, `signOut`.

--- a/docs/frontend/styling-theming.md
+++ b/docs/frontend/styling-theming.md
@@ -1,0 +1,58 @@
+# Styling and Theming
+
+Library: styled-components
+
+Theme System
+- Consistent styling via styled-components and a shared theme
+- Theme constants in `packages/talvra-constants`
+- All styling goes through the theme system
+
+Theme Structure
+```ts
+const theme = {
+  colors: {
+    primary: '#007bff',
+    secondary: '#6c757d',
+    success: '#28a745',
+    danger: '#dc3545',
+    warning: '#ffc107',
+    info: '#17a2b8',
+    light: '#f8f9fa',
+    dark: '#343a40'
+  },
+  spacing: {
+    xs: '4px',
+    sm: '8px',
+    md: '16px',
+    lg: '24px',
+    xl: '32px'
+  },
+  typography: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: {
+      sm: '14px',
+      md: '16px',
+      lg: '18px',
+      xl: '24px'
+    }
+  }
+};
+```
+
+Usage
+```tsx
+import styled from 'styled-components';
+
+const StyledCard = styled.div`
+  background: ${props => props.theme.colors.light};
+  padding: ${props => props.theme.spacing.md};
+  border-radius: 8px;
+  font-family: ${props => props.theme.typography.fontFamily};
+`;
+```
+
+Rules
+- No inline styles
+- Use theme variables for all colors, spacing, and typography
+- Consistent component styling patterns
+- Responsive design through theme breakpoints

--- a/docs/frontend/testing.md
+++ b/docs/frontend/testing.md
@@ -1,0 +1,16 @@
+# Testing
+
+Tools
+- Vitest for unit tests.
+- React Testing Library for components.
+- Playwright for e2e later.
+
+What to test
+- UI primitives render with theme and basic accessibility.
+- `useAPI` handles success, error, and retry.
+- Area hooks return shaped data and call routes with correct params.
+- Routing renders each page from `FRONT_ROUTES`.
+- No raw tags slip into Areas. Lint runs in CI.
+
+Data
+- Mock fetch with MSW. Provide fixtures for common endpoints.

--- a/docs/frontend/ui-library.md
+++ b/docs/frontend/ui-library.md
@@ -1,0 +1,40 @@
+# UI Library
+
+Package: `@ui` (talvra-ui)
+
+Rules
+- Pages do not use raw HTML tags. Only custom primitives from `@ui`.
+- UI components are dumb. Business logic and data live in hooks.
+- All components follow consistent design patterns.
+
+Component Structure
+- Import from `@ui` alias
+- Components are typed with TypeScript
+- No business logic in UI components
+- Props interface clearly defined
+
+Examples
+```tsx
+import { Button, Card, Input, Text } from '@ui';
+
+// Good: Using UI primitives
+<Card>
+  <Text variant="heading">Title</Text>
+  <Input placeholder="Enter text" />
+  <Button onClick={handleClick}>Submit</Button>
+</Card>
+
+// Bad: Using raw HTML
+<div>
+  <h1>Title</h1>
+  <input placeholder="Enter text" />
+  <button onClick={handleClick}>Submit</button>
+</div>
+```
+
+Available Components
+- Layout: Card, Container, Stack, Grid
+- Typography: Text, Heading
+- Forms: Input, Button, Select, Checkbox
+- Navigation: Link, Menu
+- Feedback: Alert, Loading, Modal

--- a/docs/handbook.json
+++ b/docs/handbook.json
@@ -1,0 +1,210 @@
+{
+    "process_handbook": {
+      "version": "1.0",
+      "pr": {
+        "principles": [
+          "One logical change per PR",
+          "Keep PRs small",
+          "Code, tests, and docs move together",
+          "Update OpenAPI and run codegen when endpoints change"
+        ],
+        "branching": {
+          "rule": "Create a branch per task",
+          "naming_examples": ["phase3/ingestion-pptx", "frontend/courses-page", "backend/auth-argon2"]
+        },
+        "template_checklist": [
+          "Summary of what changed and why",
+          "Scope of affected services or areas",
+          "How it was tested: unit, contract, integration, screenshots or logs if UI changed",
+          "Rollback plan",
+          "Docs updated",
+          "OpenAPI updated and codegen ran",
+          "Lint and types pass",
+          "Tests added or updated",
+          "No raw tags in Areas",
+          "Routes use FRONT_ROUTES and buildPath"
+        ],
+        "reviews": {
+          "owners_required": true,
+          "ci_must_be_green": true
+        }
+      },
+      "commits": {
+        "format": "type(scope): short summary",
+        "types": ["feat", "fix", "refactor", "perf", "test", "docs", "chore", "build", "ci"],
+        "rules": [
+          "Imperative mood",
+          "Subject under 72 chars",
+          "Reference issue or task id when useful"
+        ],
+        "examples": [
+          "feat(auth): add Argon2id hashing",
+          "fix(ingestion): handle ppt with embedded video",
+          "docs(frontend): add routing constants guide"
+        ]
+      },
+      "ownership": {
+        "paths": [
+          { "glob": "apps/web/**", "owner": "frontend" },
+          { "glob": "packages/talvra-ui/**", "owner": "frontend" },
+          { "glob": "packages/talvra-api/**", "owner": "frontend" },
+          { "glob": "services/**", "owner": "backend" },
+          { "glob": "migrations/**", "owner": "backend" },
+          { "glob": "docs/**", "owner": "product" }
+        ]
+      },
+      "ci_gates": {
+        "lint": true,
+        "typecheck": true,
+        "unit_tests": { "enabled": true, "coverage_min_lines": 0.8 },
+        "contract_tests": true,
+        "integration_smoke": true,
+        "openapi_diff_approved": true,
+        "frontend_guards": ["no_raw_tags_in_areas", "route_constants_only"]
+      },
+      "error_catalog": {
+        "shape": {
+          "error": {
+            "code": "string",
+            "message": "human readable",
+            "details": {},
+            "request_id": "uuid"
+          }
+        },
+        "codes": [
+          { "code": "UNAUTHENTICATED", "http": 401 },
+          { "code": "FORBIDDEN", "http": 403 },
+          { "code": "NOT_FOUND", "http": 404 },
+          { "code": "INVALID_ARGUMENT", "http": 400 },
+          { "code": "CONFLICT", "http": 409 },
+          { "code": "RATE_LIMITED", "http": 429 },
+          { "code": "INTERNAL", "http": 500 }
+        ],
+        "guidelines": [
+          "Do not leak internals",
+          "Always include request_id",
+          "Map validation failures to INVALID_ARGUMENT with field hints"
+        ]
+      },
+      "rate_limits": {
+        "auth": { "login_per_min_ip": 5, "oauth_callback_per_min_ip": 10 },
+        "canvas_sync": { "manual_per_min_user": 2 },
+        "search": { "per_min_user": 60 },
+        "policy": { "status": 429, "retry_after_header": true, "structured_logs": true }
+      },
+      "security_data": {
+        "secrets": ["env or secret manager only", "rotate on schedule"],
+        "pii": ["school email only", "encrypt Canvas tokens at rest"],
+        "retention_days": { "documents_media": 180, "logs": 90 },
+        "deletion": { "on_request_days": 7 },
+        "access": ["signed urls only for clients", "least privilege for service tokens"]
+      },
+      "runbooks": {
+        "reprocess_document": [
+          "Publish ingest.request with same doc_id",
+          "Workers are idempotent"
+        ],
+        "stuck_consumer": [
+          "Claim pending messages older than timeout to a fresh consumer",
+          "Restart worker and watch lag"
+        ],
+        "ai_error_spike": [
+          "Rotate or switch AI key",
+          "Enable backoff and circuit breaker"
+        ],
+        "blob_write_failures": [
+          "Serve cached markdown from Postgres if available",
+          "Queue write for later"
+        ],
+        "secret_rotation": [
+          "Update env",
+          "Restart service",
+          "Verify health and smoke tests"
+        ],
+        "purge_old_logs": [
+          "Delete logs where ts older than 90 days"
+        ]
+      },
+      "releases": {
+        "versioning": "semver per service",
+        "image_tags": ["semver", "git sha"],
+        "changelog": "generated from commit types",
+        "flow": ["merge to main", "CI builds and tags", "deploy to staging", "smoke tests", "promote to prod"]
+      },
+      "adrs": {
+        "when_to_write": ["new service", "new datastore or queue", "cross cutting change"],
+        "template": ["context", "options considered", "decision", "consequences"],
+        "location": "docs/process/adr/NNN-title.md"
+      },
+      "frontend_guardrails": {
+        "stack": ["React", "Vite", "React Router v6", "styled-components", "react-query"],
+        "rules": [
+          "Areas folder for features",
+          "No raw HTML tags in pages or Area components",
+          "Use Talvra UI primitives from @ui",
+          "All data fetching uses useAPI on top of react-query",
+          "Frontend routes live in src/app/routes.ts",
+          "API routes live in packages/talvra-routes via OpenAPI codegen"
+        ],
+        "performance": {
+          "first_load_bundle_gzip_kb_max": 200,
+          "route_chunk_gzip_kb_max": 100,
+          "practices": ["lazy load Areas", "memoize heavy lists", "avoid inline functions in hot paths"]
+        },
+        "a11y": [
+          "Keyboard reachable controls",
+          "Visible focus states",
+          "Labels for inputs",
+          "Contrast meets AA",
+          "Use Text component with semantic prop when needed"
+        ]
+      },
+      "backend_guardrails": [
+        "No ORM, raw SQL migrations",
+        "Idempotent workers",
+        "Small payloads on streams",
+        "Encrypt Canvas tokens",
+        "Rate limit auth and sync",
+        "Request ids through logs",
+        "Health endpoints per service"
+      ],
+      "codegen_sync": {
+        "backend_to_frontend": [
+          "API Gateway serves OpenAPI at /openapi.json",
+          "Run codegen to produce typed clients in talvra-api and route constants in talvra-routes"
+        ],
+        "frontend_routes": [
+          "Add new pages only in src/app/routes.ts",
+          "Build React Router config from those constants"
+        ]
+      },
+      "checklists": {
+        "add_backend_endpoint": [
+          "Implement handler and contract",
+          "Update OpenAPI",
+          "Add unit and contract tests",
+          "Run codegen",
+          "Update docs"
+        ],
+        "add_frontend_page": [
+          "Create component in the Area",
+          "Add a route object in src/app/routes.ts",
+          "Use Talvra UI primitives only",
+          "Use useAPI for data",
+          "Add tests and screenshots"
+        ],
+        "add_stream_message": [
+          "Define schema",
+          "Validate on publish and on consume",
+          "Make handlers idempotent",
+          "Add integration test with Redis"
+        ],
+        "ai_agent_pr": [
+          "Create branch phaseX or frontend or backend",
+          "Describe what changed and why",
+          "Explain how it was tested and results",
+          "Ensure CI is green"
+        ]
+      }
+    }
+  }

--- a/docs/integrations/canvas-api.md
+++ b/docs/integrations/canvas-api.md
@@ -1,0 +1,319 @@
+Awesome. I pulled the official Canvas API docs and turned the bits we need into a single, practical markdown you can drop in your repo. I kept it human, cited the key claims, and avoided auto submission or anything non compliant.
+
+Below is the full file. Save it as docs/integrations/canvas-api.md.
+
+⸻
+
+Canvas REST API integration guide
+
+Purpose
+Make our app read a student’s Canvas data in a safe, compliant way so we can generate notes, slides, flashcards, videos and reminders. No auto submissions. No cheating. We only read content and create study aids that the student can download and submit themselves if an assignment asks for a file.
+
+What this document covers
+	•	How Canvas auth works in practice for our app
+	•	Rate limits, pagination and safe request patterns
+	•	The exact endpoints we will use and why
+	•	How to fetch files correctly, including videos and audio
+	•	How to handle media captions for transcripts when available
+	•	Sync strategy and data mapping to Postgres
+	•	Edge cases and compliance guardrails
+
+⸻
+
+Base URL and instances
+
+Canvas is hosted per school. Every call goes to that school’s domain with the common path prefix /api/v1. Example pattern:
+
+https://{school-domain}/api/v1/...
+
+Canvas exposes a standard REST API surface for courses, modules, files, assignments and more. This is all documented in Instructure’s developer portal.  ￼
+
+⸻
+
+Authentication
+
+We will use OAuth 2.0 with a Developer Key. This is the standard Canvas pattern for third party apps. Tokens created after Oct 2015 expire in one hour and you must use refresh tokens to get new access tokens. Store tokens securely and refresh when needed.  ￼
+
+Key points we follow:
+	•	Register a Developer Key in the school’s Canvas by an admin or request a global developer key if applicable. Scopes can restrict what endpoints a token can call. If scopes are enabled, the token must request scopes that are a subset of what the key allows.  ￼
+	•	Access tokens expire and must be refreshed using the refresh token. When an access token expires the API will return 401. The docs note you can distinguish this 401 by checking the WWW-Authenticate header.  ￼
+	•	We will request only read scopes we need. If includes are restricted by scopes, the key needs the option that allows include params. The scopes list is published in the docs.  ￼
+
+Endpoints for OAuth:
+	•	GET /login/oauth2/auth to start the flow
+	•	POST /login/oauth2/token to exchange code and to refresh
+	•	DELETE /login/oauth2/token to revoke
+The overview and endpoint details are linked from the OAuth docs.  ￼
+
+⸻
+
+Pagination
+
+Canvas paginates list endpoints. Default page size is 10. You can pass per_page but there is no guaranteed max, so always follow the Link header to traverse pages. Do not assume counts. Treat the Link values as opaque.  ￼
+
+We will:
+	•	Ask for a reasonable per_page like 50 but still follow Link: rel="next" until it disappears
+	•	If auth is provided via query string access_token, Canvas will not echo it in Link headers, so re-append if you use that style. We will use Authorization headers instead.  ￼
+
+⸻
+
+Rate limiting and concurrency
+
+Canvas throttles by cost and quota. A throttled request returns HTTP 403 with message Rate Limit Exceeded. Every response can include X-Request-Cost and when throttling applies you also get X-Rate-Limit-Remaining. Parallel requests incur a pre flight penalty. Quotas refill over time and per access token. Single threaded callers are unlikely to be throttled.  ￼
+
+We will:
+	•	Keep concurrency modest per user token
+	•	Exponential backoff on 403 throttle with jitter
+	•	Read X-Rate-Limit-Remaining and dial down if it gets low
+
+⸻
+
+What we need to fetch
+
+We only need read access to the following resource families. These are the concrete endpoints we will call and the fields we care about.
+
+Courses
+
+Use this to list a user’s active courses and basic metadata for navigation and course context.
+	•	GET /api/v1/courses filter by enrollment if needed
+	•	Some responses can include a course_progress object when you ask for it which shows requirement counts and next requirement url. Helpful for reminders and study pacing.  ￼ ￼
+
+Modules and Module Items
+
+Modules represent the course content structure. Items are the actual content nodes such as files, pages, assignments, external links and more.
+	•	GET /api/v1/courses/:course_id/modules?include=items for the outline
+	•	Each item has a type like File, Page, Assignment, ExternalUrl and a reference id to fetch the real content.  ￼
+
+Files and Folders
+
+Where most PDFs, Word docs, PowerPoints and uploads live.
+	•	GET /api/v1/courses/:course_id/files to list course files
+	•	GET /api/v1/files/:id to retrieve file metadata. The file object includes a download url or public_url. Use that url to download the bytes. The url may contain a verifier token and can expire. Do not try to guess the pattern. Follow the value you receive.  ￼
+
+Pages
+
+Canvas pages are wiki style HTML content. We can fetch and convert to markdown for analysis.
+	•	GET /api/v1/courses/:course_id/pages
+	•	GET /api/v1/courses/:course_id/pages/:page_url for full HTML. Reference in the Resources index.
+
+Assignments
+
+We read assignments for due dates, allowed submission types and description context so we can generate the right study outputs and a draft file if the assignment asks for one. We will not submit on the student’s behalf.
+	•	GET /api/v1/courses/:course_id/assignments
+	•	Fields include due_at, submission_types, allowed_extensions, and more.
+
+Quizzes
+
+Classic Quizzes are available under the REST API. New Quizzes has separate resources and capability differences. Treat quizzes like read only metadata for planning and review. We do not fetch question banks unless the institution allows it and the scope permits it. Refer to Quizzes pages in the docs.  ￼
+
+Calendar and planner
+
+For reminders we can read upcoming events or planner items for a user to prompt study cadence without touching grades.
+	•	Use Calendar Events or Planner resources. See Resources section in the docs.  ￼
+
+⸻
+
+Media and captions for video and audio
+
+If a module item or file points to a video or audio, Canvas may represent it as a file link, a page with an embedded player, an external url, or a Canvas Media Object when the school uses Kaltura or Studio. For transcripts we prefer official captions if available.
+	•	The Media Objects API lets you list media tracks such as caption tracks and retrieve their content when available. This can give us text for transcripts without running our own ASR. Endpoints include listing media objects and listing media tracks for a media object or attachment.  ￼ ￼
+	•	If tracks are not accessible or there is only an embedded player, we capture the file url when present and fall back to local transcription with our speech pipeline. We never try to scrape private players.
+
+Submissions API notes: the API allows adding media comments or file uploads for submissions, but there is no API to generate or list media comments broadly and we are not submitting anyway. Good to know when reading docs so we do not rely on it.  ￼
+
+⸻
+
+File uploads and why we avoid submission
+
+Canvas has a multi step upload workflow with signed URLs. There are two supported modes.
+	•	Upload via POST in three steps
+	•	Upload via providing a public URL that Canvas clones
+The docs describe where to POST and the final confirmation step. We will not use these to submit assignments on a student’s behalf. We may use uploads only if the user explicitly chooses to upload their generated file to their own User Files, not to an assignment.  ￼
+
+⸻
+
+End to end sync plan
+
+We want a fast, respectful, resumable sync. Here is the baseline routine.
+	1.	After OAuth, detect the base Canvas domain and store tokens with encryption.
+	2.	List user courses and keep only current or enrolled courses. Paginate.  ￼
+	3.	For each course, fetch modules with include=items. Paginate.  ￼
+	4.	For each module item:
+	•	If File, call Files API to get metadata and the download url. Download and store to Azure Blob.  ￼
+	•	If Page, fetch HTML and convert to markdown.
+	•	If Assignment, fetch details for due date and instructions.
+	•	If ExternalUrl, record the link for context.
+	•	If media object or attachment has tracks, try Media Objects tracks for captions. If available, store transcript text.  ￼
+	5.	Respect rate limits. If you see 403 Rate Limit Exceeded, back off and retry later. Watch X-Request-Cost and X-Rate-Limit-Remaining.  ￼
+	6.	Convert everything to our canonical content model for AI.
+	7.	Generate notes, slides, flashcards and optional study videos.
+	8.	Index the analysis text for semantic search.
+
+Incremental sync
+Use updated_at fields where available. Since not all resources expose ETags, keep a last seen timestamp per resource type per course and re crawl with filters where supported. If no filters exist, use a cheap head list and diff IDs.
+
+Optional near real time
+Canvas provides Live Events for institutions that enable it. If available, we can subscribe and push deltas to our queue. This is optional and varies by school.  ￼
+
+⸻
+
+Data mapping to Postgres
+
+We switched to Postgres on Neon. No ORM. We keep migrations that define these tables at minimum. The AI agent will generate the exact DDL.
+	•	canvas_accounts minimal info if needed for domain binding
+	•	canvas_users stores the Canvas user id per app user
+	•	courses core fields, enrollment role, term and timestamps
+	•	modules and module_items layout with type and native id
+	•	files file metadata including content type, size, Canvas file id, source url and our blob url
+	•	pages page id, url, title and HTML snapshot
+	•	assignments id, name, due_at, submission_types, allowed_extensions
+	•	media_tracks if captions are fetched, keep locale, kind and text
+	•	ingest_runs track sync state, rate limit pauses and cursors
+
+⸻
+
+Our canonical content model
+
+We keep both formats so the AI has structure and the UI has portable text.
+	•	Markdown for human readable notes and slides input
+	•	JSON for machine friendly segments. Example:
+
+{
+  "source_id": "canvas:file:12345",
+  "kind": "document",
+  "title": "Week 3 Thermodynamics",
+  "chunks": [
+    { "type": "heading", "level": 2, "text": "First Law" },
+    { "type": "text", "text": "Energy is conserved..." },
+    { "type": "media_ref", "media_type": "video", "canvas_file_id": 6789, "transcript_ref": "media_track:abc" }
+  ],
+  "metadata": {
+    "course_id": 1111,
+    "module_item_id": 2222,
+    "content_type": "File",
+    "content_format": "pdf"
+  }
+}
+
+
+⸻
+
+Download rules
+	•	Always follow the file’s url or public_url from Files API. Do not attempt to build URLs yourself. These can contain verifier parameters.  ￼
+	•	Cache files in Azure Blob with a stable key. Keep original content type and size for reproducibility.
+	•	For pages, store original HTML and our markdown conversion.
+	•	For media, prefer caption tracks from Media Objects when the school exposes them. Otherwise treat as normal files and let our transcription handle it. Do not bypass auth walls.  ￼
+
+⸻
+
+Compliance guardrails
+	•	Do not call submission APIs for students. We only generate study outputs and leave submission to the user.
+	•	Keep scopes minimal and read focused. If scopes are enabled and include parameters are blocked, ask the admin to turn on the include option for the key so we can use include=items on modules.  ￼
+	•	Handle throttling gracefully. No aggressive retry loops.  ￼
+	•	Privacy. Store only what we need. Encrypt tokens at rest. Support logout and token revocation. Token storage and logout guidance is covered in OAuth docs.  ￼
+
+⸻
+
+Minimal endpoint cookbook
+
+The quick list our services will actually call.
+
+Courses
+	•	GET /api/v1/courses
+
+Modules
+	•	GET /api/v1/courses/:course_id/modules?include=items
+	•	GET /api/v1/courses/:course_id/modules/:module_id/items
+
+Files
+	•	GET /api/v1/courses/:course_id/files
+	•	GET /api/v1/files/:id then download using the file’s url or public_url  ￼
+
+Pages
+	•	GET /api/v1/courses/:course_id/pages
+	•	GET /api/v1/courses/:course_id/pages/:page_url
+
+Assignments
+	•	GET /api/v1/courses/:course_id/assignments for due dates and instructions.
+
+Media objects and tracks
+	•	GET /api/v1/media_objects
+	•	GET /api/v1/media_objects/:media_object_id/media_tracks
+	•	GET /api/v1/media_attachments/:attachment_id/media_tracks to fetch caption content when available.  ￼
+
+OAuth
+	•	GET /login/oauth2/auth
+	•	POST /login/oauth2/token
+	•	DELETE /login/oauth2/token for revocation. Tokens expire in one hour and require refresh.  ￼
+
+Pagination
+	•	Always parse Link headers and follow rel="next". Default page size is 10.  ￼
+
+Throttling
+	•	Watch for HTTP 403 Rate Limit Exceeded. Use X-Request-Cost and X-Rate-Limit-Remaining to adapt.  ￼
+
+⸻
+
+Service responsibilities
+	•	Canvas Connector service
+	•	Owns OAuth flow and token storage
+	•	Crawls courses, modules, items
+	•	Expands files and pages
+	•	Optional media track fetch
+	•	Emits normalized content to the ingest queue
+	•	File Fetcher
+	•	Downloads files using the file url from Canvas
+	•	Stores bytes in Azure Blob and records metadata
+	•	Hands off to text extraction
+	•	Text Extraction
+	•	Converts PDFs, docs, slides to markdown and JSON chunks
+	•	Detects embedded media references
+	•	Study Builder
+	•	Creates notes, slides, flashcards, and optional explainer videos
+	•	Indexes analysis text for semantic search
+	•	Reminder engine
+	•	Uses assignment due_at and calendar items to schedule reminders
+	•	No write to Canvas grades or submissions
+
+⸻
+
+Error handling patterns
+	•	401 with WWW-Authenticate means token expired or revoked. Re run OAuth.  ￼
+	•	403 Rate Limit Exceeded. Back off and retry later.  ￼
+	•	404 on a file that was moved. Remove local reference and resync the course files list.
+
+⸻
+
+Quick test plan
+	•	Authenticate a test user against a demo Canvas instance
+	•	Pull one course with modules and items
+	•	Verify pagination handling by forcing small per_page and walking Link headers.  ￼
+	•	Download a PDF and a PPTX file through Files API. Confirm bytes saved and checksum.  ￼
+	•	Fetch a Canvas page and convert to markdown
+	•	Read assignments and verify due dates render in the UI.
+	•	If the instance supports Media Objects, list tracks for a known media attachment and store caption text.  ￼
+	•	Simulate throttling by parallelizing calls in a staging account and confirm backoff logic.  ￼
+
+⸻
+
+Notes and caveats
+	•	Some schools disable or restrict scopes. Work with admins to enable the minimum read scopes we listed. The scopes list and scope behavior are documented.  ￼
+	•	New Quizzes has different behaviors than Classic Quizzes. Treat quizzes as schedule and context only unless the institution grants specific read access.  ￼
+	•	File upload flows exist but we will not auto submit work. The upload flow is three step and supports cloning by URL. Keep this in mind only for optional user file uploads outside of submissions.  ￼
+
+⸻
+
+References
+	•	Canvas LMS developer portal entry point and basics.  ￼
+	•	OAuth overview and lifetime notes.  ￼
+	•	Developer keys and scopes.  ￼
+	•	Pagination details and Link header behavior.  ￼
+	•	Throttling behavior and headers.  ￼
+	•	Modules and items.  ￼
+	•	Files resource and file URLs.  ￼
+	•	Assignments resource.
+	•	Media Objects and tracks.  ￼
+
+⸻
+
+If you want, I can also drop a companion canvas-api.checklist.md with scope names to request and a copy paste Postman collection, but this gets you a clean, compliant spec to feed your agent today.

--- a/docs/scripts/VALIDATION.md
+++ b/docs/scripts/VALIDATION.md
@@ -1,0 +1,141 @@
+here’s a single prompt you can paste to your AI agent to create the validator.
+
+⸻
+
+Prompt for AI agent: Create process.json validator
+
+Goal
+Add a TypeScript script that validates docs/process.json against our required schema. Fail CI if it is missing keys or has wrong types.
+
+Scope
+	•	Create scripts/validate-process-json.ts
+	•	Keep file under 100 lines
+	•	No network calls
+	•	Clear error messages with paths
+	•	Exit code 1 on validation failure, 0 on success
+	•	Wire into pnpm scripts and CI
+
+Tech choices
+	•	Use zod for schema validation
+	•	Use tsx to run TypeScript directly
+
+Repo context
+	•	Monorepo with pnpm
+	•	Root has docs/process.json that contains a top level process_handbook object
+
+Required schema to validate
+Top level
+
+{
+  process_handbook: {
+    version: string,
+    pr: {
+      principles: string[],
+      branching: { rule: string, naming_examples: string[] },
+      template_checklist: string[],
+      reviews: { owners_required: boolean, ci_must_be_green: boolean }
+    },
+    commits: {
+      format: string,
+      types: string[],
+      rules: string[],
+      examples: string[]
+    },
+    ownership: {
+      paths: Array<{ glob: string, owner: string }>
+    },
+    ci_gates: {
+      lint: boolean,
+      typecheck: boolean,
+      unit_tests: { enabled: boolean, coverage_min_lines: number },
+      contract_tests: boolean,
+      integration_smoke: boolean,
+      openapi_diff_approved: boolean,
+      frontend_guards: string[]
+    },
+    error_catalog: {
+      shape: object,
+      codes: Array<{ code: string, http: number }>,
+      guidelines: string[]
+    },
+    rate_limits: {
+      auth: object,
+      canvas_sync: object,
+      search: object,
+      policy: object
+    },
+    security_data: {
+      secrets: string[],
+      pii: string[],
+      retention_days: { documents_media: number, logs: number },
+      deletion: { on_request_days: number },
+      access: string[]
+    },
+    runbooks: object,
+    releases: object,
+    adrs: object,
+    frontend_guardrails: {
+      stack: string[],
+      rules: string[],
+      performance: { first_load_bundle_gzip_kb_max: number, route_chunk_gzip_kb_max: number, practices: string[] },
+      a11y: string[]
+    },
+    backend_guardrails: string[],
+    codegen_sync: object,
+    checklists: {
+      add_backend_endpoint: string[],
+      add_frontend_page: string[],
+      add_stream_message: string[],
+      ai_agent_pr: string[]
+    }
+  }
+}
+
+Tasks
+	1.	Add dev dependencies
+	•	pnpm add -D zod tsx at repo root
+	2.	Create scripts/validate-process-json.ts
+Behavior
+	•	Read docs/process.json
+	•	Parse JSON
+	•	Validate with zod schema that matches the Required schema above
+	•	On error print lines like
+process.json invalid at process_handbook.pr.reviews.ci_must_be_green expected boolean
+Exit 1
+	•	On success print
+process.json valid
+Exit 0
+Constraints
+	•	Keep file under 100 lines
+	•	No dynamic imports
+	•	No console noise other than result or errors
+	3.	Add package scripts in root package.json
+
+"scripts": {
+  "validate:process": "tsx scripts/validate-process-json.ts",
+  "validate": "pnpm run validate:process"
+}
+
+
+	4.	CI integration
+	•	Update .github/workflows/ci.yml to run pnpm run validate:process before lint and typecheck
+	5.	Optional tests
+	•	Add scripts/__tests__/validate-process-json.test.ts with Vitest
+	•	One passing case that loads the real file
+	•	One failing case that feeds a minimal invalid object
+	•	Keep test file under 100 lines
+	6.	Output
+	•	Open a PR on branch tooling/process-validator
+	•	PR description must include
+	•	What changed
+	•	Why we need schema validation
+	•	How it was tested
+	•	Sample output for pass and fail
+	•	Include a short note confirming the file is under 100 lines
+
+Acceptance criteria
+	•	Running pnpm run validate:process prints process.json valid on current file
+	•	Breaking a required boolean to a string causes exit code 1 with a clear path in the error message
+	•	CI runs the validator and fails when the schema is broken
+	•	Script file is under 100 lines
+	•	No other files exceed the 100 line guideline due to this change

--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -1,0 +1,650 @@
+{
+  "task_plan_version": "1.0",
+  "phases": [
+    {
+      "name": "Phase 0 - Repo and CI basics",
+      "tasks": [
+        {
+          "id": "T000",
+          "title": "Initialize monorepo and workspace",
+          "branch": "tooling/init-monorepo",
+          "paths": ["package.json", "pnpm-workspace.yaml", ".editorconfig", ".gitignore", "README.md"],
+          "steps": [
+            "Create pnpm workspace and root scripts",
+            "Add README with alias guidance"
+          ],
+          "run": ["pnpm install"],
+          "acceptance": [
+            "pnpm install succeeds",
+            "pnpm -r list shows workspace"
+          ],
+          "pr": {
+            "title": "chore(repo) init pnpm workspace and repo meta",
+            "body": "Why: set foundation for multi apps. What changed: workspace files. Tests: install ok."
+          },
+          "completed": true
+        },
+        {
+          "id": "T001",
+          "title": "Add CI workflow skeleton",
+          "branch": "tooling/ci-skeleton",
+          "paths": [".github/workflows/ci.yml"],
+          "steps": ["Add checkout and pnpm install steps"],
+          "run": [],
+          "acceptance": ["CI runs and passes on PR"],
+          "pr": {
+            "title": "ci: add workflow skeleton",
+            "body": "Why: early CI feedback. Tests: green run on PR."
+          },
+          "completed": false
+        },
+        {
+          "id": "T002",
+          "title": "Process handbook and validator",
+          "branch": "tooling/process-handbook",
+          "paths": ["docs/process.md", "docs/process.json", "scripts/validate-process-json.ts", "package.json", ".github/workflows/ci.yml"],
+          "steps": [
+            "Add handbook and JSON",
+            "Create zod validator and pnpm script",
+            "Call validator in CI"
+          ],
+          "run": ["pnpm add -D tsx zod", "pnpm run validate:process"],
+          "acceptance": ["Validator prints process.json valid", "CI runs validator"],
+          "pr": {
+            "title": "docs(process) add handbook and JSON with validator",
+            "body": "Why: single source of truth and guard. Tests: validator pass and CI hook."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 1 - Frontend base you can run",
+      "tasks": [
+        {
+          "id": "T010",
+          "title": "Scaffold Vite React app and structure",
+          "branch": "web/scaffold",
+          "paths": ["apps/web/**", "packages/configs/**", "tsconfig.base.json"],
+          "steps": [
+            "Create Vite React TS app under apps/web",
+            "Add aliases and Areas folders",
+            "Add AppProvider, AppRoutes, routes.ts"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Dev server renders Admin page"],
+          "pr": {
+            "title": "feat(web) scaffold Vite app with Areas and routes skeleton",
+            "body": "What: Vite app, routes, Areas. Tests: dev server shows Admin."
+          },
+          "completed": false
+        },
+        {
+          "id": "T011",
+          "title": "Shared UI primitives package",
+          "branch": "web/ui-primitives",
+          "paths": ["packages/talvra-ui/**", "apps/web/.eslintrc.cjs", "packages/configs/.eslintrc.base.cjs"],
+          "steps": [
+            "Add styled-components primitives",
+            "Enforce no raw tags in Areas with ESLint override"
+          ],
+          "run": ["pnpm -r lint"],
+          "acceptance": ["Admin renders with @ui only", "Lint fails on raw tag usage"],
+          "pr": {
+            "title": "feat(ui) add Talvra UI primitives and lint guard",
+            "body": "What: primitives and guard. Tests: render Admin, lint check."
+          },
+          "completed": false
+        },
+        {
+          "id": "T012",
+          "title": "Frontend route constants as source of truth",
+          "branch": "web/front-routes-constants",
+          "paths": ["apps/web/src/app/routes.ts", "apps/web/src/app/AppRoutes.tsx", "packages/talvra-hooks/src/useTalvraNav.ts"],
+          "steps": [
+            "Define FRONT_ROUTES with lazy components",
+            "Add buildPath and useTalvraNav"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Navigation via constants works"],
+          "pr": {
+            "title": "feat(web) add FRONT_ROUTES constants and typed navigation",
+            "body": "What: routes file and helpers. Tests: navigate to pages."
+          },
+          "completed": false
+        },
+        {
+          "id": "T013",
+          "title": "React Query and useAPI hook package",
+          "branch": "web/useapi",
+          "paths": ["packages/talvra-api/src/useAPI.ts", "apps/web/src/app/AppProvider.tsx"],
+          "steps": [
+            "Add QueryClientProvider",
+            "Implement generic useAPI for GET and mutate"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Sample GET shows data in a test component"],
+          "pr": {
+            "title": "feat(api) add typed useAPI on react query",
+            "body": "What: provider and hook. Tests: sample GET."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 2 - Backend base you can run",
+      "tasks": [
+        {
+          "id": "T020",
+          "title": "Docker compose for local stack",
+          "branch": "infra/compose-base",
+          "paths": ["infra/docker-compose.yml", "infra/redis/**", "infra/azurite/**", ".env.example"],
+          "steps": [
+            "Add Postgres or Neon connection, Redis, Azurite",
+            "Document ports and env"
+          ],
+          "run": ["docker compose -f infra/docker-compose.yml up -d"],
+          "acceptance": ["All containers healthy"],
+          "pr": {
+            "title": "infra: add compose for Postgres Redis Azurite",
+            "body": "What: compose file and env. Tests: services healthy."
+          },
+          "completed": false
+        },
+        {
+          "id": "T021",
+          "title": "API Gateway service skeleton",
+          "branch": "backend/gateway-skeleton",
+          "paths": ["services/api-gateway/**"],
+          "steps": [
+            "Create Node TS service",
+            "GET /health returns ok true and request id"
+          ],
+          "run": ["pnpm --filter ./services/api-gateway dev"],
+          "acceptance": [ "curl localhost:3001/health returns ok true" ],
+          "pr": {
+            "title": "feat(gateway) skeleton with health and request id",
+            "body": "What: service base and health. Tests: curl ok."
+          },
+          "completed": false
+        },
+        {
+          "id": "T022",
+          "title": "Auth service skeleton",
+          "branch": "backend/auth-skeleton",
+          "paths": ["services/auth-service/**", "migrations/auth/**"],
+          "steps": [
+            "Add users and sessions migrations",
+            "Implement signup, login, session endpoints"
+          ],
+          "run": ["pnpm --filter ./services/auth-service dev"],
+          "acceptance": ["Signup and login work against Postgres"],
+          "pr": {
+            "title": "feat(auth) service skeleton and basic auth endpoints",
+            "body": "What: endpoints and migrations. Tests: signup and login curl."
+          },
+          "completed": false
+        },
+        {
+          "id": "T023",
+          "title": "Gateway to Auth integration with cookies",
+          "branch": "backend/gateway-auth-integration",
+          "paths": ["services/api-gateway/**"],
+          "steps": [
+            "Proxy /auth/* to Auth",
+            "Set and read HttpOnly cookie"
+          ],
+          "run": ["pnpm --filter ./services/api-gateway dev"],
+          "acceptance": ["Login through gateway sets session"],
+          "pr": {
+            "title": "feat(gateway) proxy auth and session cookies",
+            "body": "What: reverse proxy and cookie handling."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 3 - Canvas integration with fixtures first",
+      "tasks": [
+        {
+          "id": "T030",
+          "title": "Canvas service skeleton and fixtures",
+          "branch": "backend/canvas-skeleton",
+          "paths": ["services/canvas-service/**", "migrations/canvas/**"],
+          "steps": [
+            "Add courses and assignments tables",
+            "Sync from fixture JSON and expose GET endpoints"
+          ],
+          "run": ["pnpm --filter ./services/canvas-service dev"],
+          "acceptance": ["GET /canvas/courses returns fixture data"],
+          "pr": {
+            "title": "feat(canvas) service skeleton with fixture sync",
+            "body": "What: tables and endpoints. Tests: sync then read."
+          },
+          "completed": false
+        },
+        {
+          "id": "T031",
+          "title": "Gateway proxies Canvas routes",
+          "branch": "backend/gateway-canvas-proxy",
+          "paths": ["services/api-gateway/**"],
+          "steps": ["Proxy /canvas/* to canvas service"],
+          "run": [],
+          "acceptance": ["Frontend can call /api/canvas/courses via gateway"],
+          "pr": {
+            "title": "feat(gateway) proxy canvas routes",
+            "body": "What: proxy rules."
+          },
+          "completed": false
+        },
+        {
+          "id": "T032",
+          "title": "Frontend Courses list page",
+          "branch": "web/courses-list",
+          "paths": ["apps/web/src/Areas/Courses/**", "packages/talvra-routes/**"],
+          "steps": [
+            "Add GET_ALL_COURSES route constant",
+            "Create useTalvraCourses and render list"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Visiting /courses shows fixture list"],
+          "pr": {
+            "title": "feat(web) courses list using useAPI and route constants",
+            "body": "What: hook and list. Tests: manual route visit."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 4 - Ingestion pipeline start",
+      "tasks": [
+        {
+          "id": "T040",
+          "title": "Ingestion service skeleton and Redis stream",
+          "branch": "backend/ingestion-skeleton",
+          "paths": ["services/ingestion-service/**", "migrations/documents/**"],
+          "steps": [
+            "Add documents table and endpoints",
+            "Publish ingest.request on start"
+          ],
+          "run": ["pnpm --filter ./services/ingestion-service dev"],
+          "acceptance": ["POST /ingestion/start enqueues a message"],
+          "pr": {
+            "title": "feat(ingestion) service skeleton with Redis stream",
+            "body": "What: endpoints and queue."
+          },
+          "completed": false
+        },
+        {
+          "id": "T041",
+          "title": "Extract PDF and DOCX to Markdown and JSON",
+          "branch": "backend/ingestion-extractor",
+          "paths": ["services/ingestion-service/src/**"],
+          "steps": [
+            "Adapters for pdf and docx",
+            "Write markdown and structure.json to Blob"
+          ],
+          "run": ["curl -X POST /ingestion/start with fixture"],
+          "acceptance": ["Blob urls exist and document row updated"],
+          "pr": {
+            "title": "feat(ingestion) extract PDF and DOCX to md and json",
+            "body": "What: adapters and storage. Tests: fixture run."
+          },
+          "completed": false
+        },
+        {
+          "id": "T042",
+          "title": "Frontend document view page",
+          "branch": "web/documents-view",
+          "paths": ["apps/web/src/Areas/Courses/**", "packages/talvra-routes/**"],
+          "steps": [
+            "Routes to fetch documents and notes",
+            "Render document title and blob links"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Document screen shows links after processing"],
+          "pr": {
+            "title": "feat(web) document view screen",
+            "body": "What: page and routes."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 5 - AI outputs",
+      "tasks": [
+        {
+          "id": "T050",
+          "title": "AI service skeleton with mock outputs",
+          "branch": "backend/ai-skeleton",
+          "paths": ["services/ai-service/**", "migrations/ai/**"],
+          "steps": [
+            "Tables for notes and flashcards",
+            "POST /ai/start produces markdown and flashcards"
+          ],
+          "run": ["pnpm --filter ./services/ai-service dev"],
+          "acceptance": ["Notes and flashcards stored and retrievable"],
+          "pr": {
+            "title": "feat(ai) service skeleton with mock outputs",
+            "body": "What: endpoints and tables."
+          },
+          "completed": false
+        },
+        {
+          "id": "T051",
+          "title": "Frontend slides and flashcards",
+          "branch": "web/slides-flashcards",
+          "paths": ["apps/web/src/Areas/Courses/**"],
+          "steps": [
+            "Render slides with reveal.js",
+            "Render flashcards with flip cards"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Slides and flashcards visible for a processed doc"],
+          "pr": {
+            "title": "feat(web) slides and flashcards views",
+            "body": "What: pages wired to AI outputs."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 6 - Media pipeline",
+      "tasks": [
+        {
+          "id": "T060",
+          "title": "Media service and TTS stub",
+          "branch": "backend/media-skeleton",
+          "paths": ["services/media-service/**", "migrations/media/**"],
+          "steps": [
+            "POST /media/start builds MP4 with stub TTS",
+            "GET /media/:doc_id returns urls"
+          ],
+          "run": ["pnpm --filter ./services/media-service dev"],
+          "acceptance": ["MP4 and thumbnail exist in Blob"],
+          "pr": {
+            "title": "feat(media) service skeleton with stub TTS",
+            "body": "What: MP4 pipeline and storage."
+          },
+          "completed": false
+        },
+        {
+          "id": "T061",
+          "title": "Frontend video playback",
+          "branch": "web/video-player",
+          "paths": ["apps/web/src/Areas/Courses/**", "packages/talvra-ui/src/Video.tsx"],
+          "steps": [
+            "Add Video primitive",
+            "Show MP4 on document screen"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Video plays in browser"],
+          "pr": {
+            "title": "feat(web) video playback for document",
+            "body": "What: primitive and page."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 7 - Search and reminders",
+      "tasks": [
+        {
+          "id": "T070",
+          "title": "Semantic search with RedisSearch",
+          "branch": "backend/search-embeddings",
+          "paths": ["services/ai-service/**", "services/api-gateway/**"],
+          "steps": [
+            "Store embeddings for notes",
+            "GET /search returns top matches"
+          ],
+          "run": ["curl /search?q=term"],
+          "acceptance": ["Query returns expected doc ids"],
+          "pr": {
+            "title": "feat(search) semantic search over notes",
+            "body": "What: embedding index and endpoint."
+          },
+          "completed": false
+        },
+        {
+          "id": "T071",
+          "title": "Notification service and reminders",
+          "branch": "backend/notify-reminders",
+          "paths": ["services/notification-service/**", "migrations/notifications/**"],
+          "steps": [
+            "Schedule email reminders from assignments",
+            "Send test messages"
+          ],
+          "run": ["pnpm --filter ./services/notification-service dev"],
+          "acceptance": ["A test reminder is sent to dev inbox"],
+          "pr": {
+            "title": "feat(notify) assignment reminders",
+            "body": "What: scheduler and sender."
+          },
+          "completed": false
+        },
+        {
+          "id": "T072",
+          "title": "Reminders settings UI",
+          "branch": "web/reminders-settings",
+          "paths": ["apps/web/src/Areas/Admin/**"],
+          "steps": [
+            "Add settings form that calls notify API",
+            "Persist and read settings"
+          ],
+          "run": ["pnpm --filter web dev"],
+          "acceptance": ["Settings save and load correctly"],
+          "pr": {
+            "title": "feat(web) reminders settings UI",
+            "body": "What: admin UI and routes."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 8 - Canvas real OAuth and ingestion bridge",
+      "tasks": [
+        {
+          "id": "T080",
+          "title": "Canvas OAuth connect",
+          "branch": "backend/canvas-oauth",
+          "paths": ["services/canvas-service/**"],
+          "steps": [
+            "Implement real OAuth handshake",
+            "Encrypt and store tokens"
+          ],
+          "run": ["pnpm --filter ./services/canvas-service dev"],
+          "acceptance": ["Connect flow completes and tokens saved"],
+          "pr": {
+            "title": "feat(canvas) real OAuth and token storage",
+            "body": "What: OAuth endpoints and crypto."
+          },
+          "completed": false
+        },
+        {
+          "id": "T081",
+          "title": "Sync enqueues ingestion for new module items",
+          "branch": "backend/canvas-to-ingestion",
+          "paths": ["services/canvas-service/**", "services/ingestion-service/**"],
+          "steps": [
+            "Enumerate new files and publish ingest.request",
+            "Deduplicate by doc id"
+          ],
+          "run": ["Run sync and observe documents appear"],
+          "acceptance": ["New files are processed end to end"],
+          "pr": {
+            "title": "feat(canvas) enqueue ingestion for new items",
+            "body": "What: event emission and dedupe."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 9 - Logging and observability",
+      "tasks": [
+        {
+          "id": "T090",
+          "title": "Logging service with Postgres storage",
+          "branch": "backend/logging-service",
+          "paths": ["services/logging-service/**", "migrations/logs/**"],
+          "steps": [
+            "POST /logs inserts rows",
+            "Simple query endpoint"
+          ],
+          "run": ["pnpm --filter ./services/logging-service dev"],
+          "acceptance": ["Logs written and retrievable by request id"],
+          "pr": {
+            "title": "feat(logs) structured logs service and storage",
+            "body": "What: endpoint and schema."
+          },
+          "completed": false
+        },
+        {
+          "id": "T091",
+          "title": "Request id propagation",
+          "branch": "backend/request-id-plumbing",
+          "paths": ["services/**"],
+          "steps": [
+            "Gateway generates X-Request-Id",
+            "Downstream logs include it"
+          ],
+          "run": [],
+          "acceptance": ["One request is traceable across services"],
+          "pr": {
+            "title": "chore(observability) request id propagation",
+            "body": "What: header and logging."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 10 - Compliance and hardening",
+      "tasks": [
+        {
+          "id": "T100",
+          "title": "Rate limits and unified error model",
+          "branch": "backend/rate-limits-errors",
+          "paths": ["services/api-gateway/**", "services/**"],
+          "steps": [
+            "Apply rate limits per process.json",
+            "Return unified error shape"
+          ],
+          "run": ["Abuse an endpoint and see 429 with Retry-After"],
+          "acceptance": ["Error responses include request_id and codes"],
+          "pr": {
+            "title": "chore(security) rate limits and unified error shape",
+            "body": "What: middlewares and handlers."
+          },
+          "completed": false
+        },
+        {
+          "id": "T101",
+          "title": "Data retention jobs",
+          "branch": "backend/retention-jobs",
+          "paths": ["services/**"],
+          "steps": [
+            "Jobs to prune old logs and blobs",
+            "Dry run and then prune"
+          ],
+          "run": ["Run job and verify counts then deletes"],
+          "acceptance": ["Old data removed safely in dev"],
+          "pr": {
+            "title": "chore(data) retention jobs for logs and blobs",
+            "body": "What: scheduled tasks."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 11 - Codegen and sync",
+      "tasks": [
+        {
+          "id": "T110",
+          "title": "OpenAPI in gateway and frontend codegen scripts",
+          "branch": "tooling/openapi-codegen",
+          "paths": ["services/api-gateway/**", "packages/talvra-routes/**", "packages/talvra-api/**", "scripts/**"],
+          "steps": [
+            "Serve /openapi.json",
+            "Generate route constants and types for frontend"
+          ],
+          "run": ["pnpm run codegen"],
+          "acceptance": ["Generated files updated and build passes"],
+          "pr": {
+            "title": "tooling: OpenAPI and frontend codegen",
+            "body": "What: spec and generator."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
+      "name": "Phase 12 - Polishing and e2e",
+      "tasks": [
+        {
+          "id": "T120",
+          "title": "End to end demo with seeds",
+          "branch": "demo/e2e-flow",
+          "paths": ["scripts/seed/**", "README.md"],
+          "steps": [
+            "Seed student, course, and sample PDF",
+            "One command that runs stack and produces outputs"
+          ],
+          "run": ["pnpm run demo:e2e"],
+          "acceptance": ["Demo brings up UI and shows processed study aids"],
+          "pr": {
+            "title": "feat(demo) one command e2e with sample content",
+            "body": "What: seeds and demo script."
+          },
+          "completed": false
+        },
+        {
+          "id": "T121",
+          "title": "Accessibility pass on core pages",
+          "branch": "web/a11y-pass",
+          "paths": ["apps/web/**", "packages/talvra-ui/**"],
+          "steps": [
+            "Add labels and roles",
+            "Ensure visible focus and contrast"
+          ],
+          "run": ["Automated a11y checks on Admin and Courses"],
+          "acceptance": ["Checks pass on core pages"],
+          "pr": {
+            "title": "chore(web) a11y improvements on core pages",
+            "body": "What: focus, labels, roles."
+          },
+          "completed": false
+        },
+        {
+          "id": "T122",
+          "title": "Performance pass and lazy chunks",
+          "branch": "web/perf-chunks",
+          "paths": ["apps/web/**"],
+          "steps": [
+            "Lazy load Areas",
+            "Reduce initial bundle"
+          ],
+          "run": ["Analyze bundle and confirm budgets"],
+          "acceptance": [
+            "First load under 200 kb gzip",
+            "Route chunks under 100 kb"
+          ],
+          "pr": {
+            "title": "chore(web) code split Areas and tune bundles",
+            "body": "What: lazy routes and cleanup."
+          },
+          "completed": false
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "talvra",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Microservice learning app monorepo",
+  "scripts": {
+    "validate:process": "tsx scripts/validate-process-json.ts",
+    "codegen": "echo 'OpenAPI codegen placeholder'",
+    "demo:e2e": "echo 'E2E demo placeholder'",
+    "dev": "echo 'Development placeholder'"
+  },
+  "devDependencies": {},
+  "engines": {
+    "node": ">=18",
+    "pnpm": ">=8"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'services/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary of changes and motivation

Why: Set foundation for multi apps and establish proper monorepo structure with pnpm workspaces.

What changed: Added workspace configuration files, comprehensive documentation, and development setup files to enable multi-package development.

## Scope of services or Areas

- Root monorepo configuration
- Documentation structure
- Development tooling setup

## How it was tested

### Unit
N/A - Configuration files only

### Contract  
N/A - No service contracts yet

### Integration
- `pnpm install` succeeds at root level
- `pnpm -r list` shows workspace (empty but no errors as expected)
- Workspace structure ready for packages in apps/, services/, packages/

### Screenshots or logs
```
$ pnpm install
Already up to date
Done in 223ms using pnpm v10.15.0

$ pnpm -r list
(empty output - no packages yet, which is correct)
```

## Rollback plan

Simple revert of this commit - removes workspace files and returns to empty repository state.

## Checklist

- [x] Docs updated (Added comprehensive README with project structure)  
- [ ] OpenAPI updated and codegen ran (N/A for this task)
- [ ] Lint and types pass (N/A - no code yet)
- [ ] Tests added or updated (N/A for configuration)
- [ ] No raw tags in Areas (N/A - no frontend code yet)
- [ ] Routes use FRONT_ROUTES and buildPath (N/A - no routes yet)