### PR TITLE
feat(routes): T012 - extract route constants to shared package

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -1,26 +1,2 @@
-// Route definitions as single source of truth
-export const FRONT_ROUTES = {
-  ADMIN: {
-    path: '/admin',
-    name: 'Admin',
-  },
-  COURSES: {
-    path: '/courses',
-    name: 'Courses',
-  },
-} as const;
-
-// Helper to build paths with parameters
-export function buildPath(route: { path: string }, params?: Record<string, string>): string {
-  let path = route.path;
-  
-  if (params) {
-    Object.entries(params).forEach(([key, value]) => {
-      path = path.replace(`:${key}`, value);
-    });
-  }
-  
-  return path;
-}
-
-export default FRONT_ROUTES;
+// This file re-exports route constants from the shared package to preserve import paths
+export { FRONT_ROUTES, buildPath, default as default } from '@routes';

--- a/packages/talvra-routes/.eslintrc.cjs
+++ b/packages/talvra-routes/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ['../configs/.eslintrc.base.cjs'],
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
+  },
+  rules: {
+    // Allow any type for route parameter extraction
+    '@typescript-eslint/no-explicit-any': 'off',
+    
+    // Allow unused variables in some helper functions
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/talvra-routes/package.json
+++ b/packages/talvra-routes/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "talvra-routes",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Route constants and navigation utilities for Talvra learning app",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint .",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "~5.8.3"
+  },
+  "keywords": [
+    "routes",
+    "navigation",
+    "constants",
+    "talvra"
+  ],
+  "author": "Talvra Team",
+  "engines": {
+    "node": ">=18",
+    "pnpm": ">=8"
+  }
+}

--- a/packages/talvra-routes/src/index.ts
+++ b/packages/talvra-routes/src/index.ts
@@ -1,0 +1,206 @@
+// Route parameter types for type-safe navigation
+export interface RouteParams {
+  courseId?: string;
+  documentId?: string;
+  userId?: string;
+  studyAidId?: string;
+}
+
+// Route definition interface
+export interface RouteDefinition {
+  readonly path: string;
+  readonly name: string;
+  readonly params?: readonly string[];
+  readonly description?: string;
+}
+
+// Frontend route constants - single source of truth for all navigation
+export const FRONT_ROUTES = {
+  // Main application routes
+  HOME: {
+    path: '/',
+    name: 'Home',
+    description: 'Landing page',
+  },
+  
+  // Admin routes
+  ADMIN: {
+    path: '/admin',
+    name: 'Admin',
+    description: 'Administrative dashboard',
+  },
+  
+  // Course management routes
+  COURSES: {
+    path: '/courses',
+    name: 'Courses',
+    description: 'Course listing and management',
+  },
+  COURSE_DETAIL: {
+    path: '/courses/:courseId',
+    name: 'Course Detail',
+    params: ['courseId'],
+    description: 'Individual course details and content',
+  },
+  
+  // Document management routes
+  DOCUMENTS: {
+    path: '/documents',
+    name: 'Documents',
+    description: 'Document library and management',
+  },
+  DOCUMENT_DETAIL: {
+    path: '/documents/:documentId',
+    name: 'Document Detail', 
+    params: ['documentId'],
+    description: 'Individual document viewer and editor',
+  },
+  
+  // Study aids and AI features
+  STUDY_AIDS: {
+    path: '/study-aids',
+    name: 'Study Aids',
+    description: 'AI-generated study materials',
+  },
+  STUDY_AID_DETAIL: {
+    path: '/study-aids/:studyAidId',
+    name: 'Study Aid Detail',
+    params: ['studyAidId'], 
+    description: 'Individual study aid viewer',
+  },
+  
+  // User management routes
+  PROFILE: {
+    path: '/profile',
+    name: 'Profile',
+    description: 'User profile and settings',
+  },
+  USER_DETAIL: {
+    path: '/users/:userId',
+    name: 'User Detail',
+    params: ['userId'],
+    description: 'User profile (admin view)',
+  },
+  
+  // Authentication routes
+  LOGIN: {
+    path: '/login',
+    name: 'Login',
+    description: 'User authentication',
+  },
+  LOGOUT: {
+    path: '/logout',
+    name: 'Logout', 
+    description: 'User logout',
+  },
+  
+  // Integration routes
+  CANVAS_SYNC: {
+    path: '/canvas/sync',
+    name: 'Canvas Sync',
+    description: 'Canvas LMS integration sync',
+  },
+  
+  // Settings routes
+  SETTINGS: {
+    path: '/settings',
+    name: 'Settings',
+    description: 'Application settings',
+  },
+} as const;
+
+// Type for route keys
+export type RouteKey = keyof typeof FRONT_ROUTES;
+
+// Helper to build paths with parameters and type safety
+export function buildPath(
+  route: RouteDefinition, 
+  params?: RouteParams
+): string {
+  let path = route.path;
+  
+  // Replace parameters if provided
+  if (params && route.params) {
+    route.params.forEach(param => {
+      const value = params[param as keyof RouteParams];
+      if (value) {
+        path = path.replace(`:${param}`, value);
+      }
+    });
+  }
+  
+  return path;
+}
+
+// Helper to validate that all required parameters are provided
+export function validateRouteParams(
+  route: RouteDefinition,
+  params?: RouteParams
+): boolean {
+  if (!route.params) return true;
+  
+  if (!params) return false;
+  
+  return route.params.every(param => {
+    const value = params[param as keyof RouteParams];
+    return value !== undefined && value !== null && value !== '';
+  });
+}
+
+// Helper to extract parameters from a path
+export function extractParams(
+  route: RouteDefinition,
+  currentPath: string
+): RouteParams | null {
+  if (!route.params) return {};
+  
+  // Create regex from route path
+  const regexPath = route.path.replace(/:[^/]+/g, '([^/]+)');
+  const regex = new RegExp(`^${regexPath}$`);
+  
+  const match = currentPath.match(regex);
+  if (!match) return null;
+  
+  const params: RouteParams = {};
+  route.params.forEach((param, index) => {
+    (params as any)[param] = match[index + 1];
+  });
+  
+  return params;
+}
+
+// Helper to check if a route matches a path
+export function matchesRoute(
+  route: RouteDefinition,
+  currentPath: string
+): boolean {
+  if (!route.params) {
+    return route.path === currentPath;
+  }
+  
+  const regexPath = route.path.replace(/:[^/]+/g, '[^/]+');
+  const regex = new RegExp(`^${regexPath}$`);
+  
+  return regex.test(currentPath);
+}
+
+// Get all routes as an array for iteration
+export function getAllRoutes(): RouteDefinition[] {
+  return Object.values(FRONT_ROUTES);
+}
+
+// Get routes by category helper
+export function getRoutesByCategory() {
+  return {
+    main: [FRONT_ROUTES.HOME, FRONT_ROUTES.ADMIN],
+    courses: [FRONT_ROUTES.COURSES, FRONT_ROUTES.COURSE_DETAIL],
+    documents: [FRONT_ROUTES.DOCUMENTS, FRONT_ROUTES.DOCUMENT_DETAIL],
+    studyAids: [FRONT_ROUTES.STUDY_AIDS, FRONT_ROUTES.STUDY_AID_DETAIL],
+    user: [FRONT_ROUTES.PROFILE, FRONT_ROUTES.USER_DETAIL],
+    auth: [FRONT_ROUTES.LOGIN, FRONT_ROUTES.LOGOUT],
+    integration: [FRONT_ROUTES.CANVAS_SYNC],
+    settings: [FRONT_ROUTES.SETTINGS],
+  };
+}
+
+export default FRONT_ROUTES;

--- a/packages/talvra-routes/tsconfig.json
+++ b/packages/talvra-routes/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 5.1.34
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.1(vite@7.1.3(tsx@4.20.4))
+        version: 5.0.1(vite@7.1.3(@types/node@20.19.11)(tsx@4.20.4))
       eslint:
         specifier: ^9.33.0
         version: 9.34.0
@@ -68,7 +68,7 @@ importers:
         version: 8.40.0(eslint@9.34.0)(typescript@5.8.3)
       vite:
         specifier: ^7.1.2
-        version: 7.1.3(tsx@4.20.4)
+        version: 7.1.3(@types/node@20.19.11)(tsx@4.20.4)
 
   packages/configs:
     devDependencies:
@@ -81,6 +81,15 @@ importers:
       eslint:
         specifier: ^8.45.0
         version: 8.57.1
+
+  packages/talvra-routes:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.11
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   packages/talvra-ui:
     dependencies:
@@ -589,6 +598,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.11':
+    resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
@@ -1388,6 +1400,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -1872,6 +1887,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@20.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/react-dom@19.1.7(@types/react@19.1.11)':
     dependencies:
       '@types/react': 19.1.11
@@ -2082,7 +2101,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.0.1(vite@7.1.3(tsx@4.20.4))':
+  '@vitejs/plugin-react@5.0.1(vite@7.1.3(@types/node@20.19.11)(tsx@4.20.4))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -2090,7 +2109,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.32
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.3(tsx@4.20.4)
+      vite: 7.1.3(@types/node@20.19.11)(tsx@4.20.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -2770,6 +2789,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  undici-types@6.21.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.25.3):
     dependencies:
       browserslist: 4.25.3
@@ -2780,7 +2801,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.1.3(tsx@4.20.4):
+  vite@7.1.3(@types/node@20.19.11)(tsx@4.20.4):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2789,6 +2810,7 @@ snapshots:
       rollup: 4.48.0
       tinyglobby: 0.2.14
     optionalDependencies:
+      '@types/node': 20.19.11
       fsevents: 2.3.3
       tsx: 4.20.4
 


### PR DESCRIPTION
**Summary:**
Create talvra-routes shared package and move FRONT_ROUTES + helpers from the web app to the shared package with stronger typing and utilities. Update the web app to re-export from @routes to preserve import paths in existing code.

**Scope:**
- packages/talvra-routes: new package with route constants, typing, and helpers (buildPath, validateRouteParams, extractParams, matchesRoute)
- apps/web/src/app/routes.ts: now re-exports from @routes
- tsconfig path aliases already supported; ensured integration works

**Details:**
- Added readonly types for RouteDefinition to match const route objects
- Added validation and parsing helpers for dynamic routes
- Added categorical getters for convenience

**Testing:**
- [x] Type-check talvra-routes (tsc --noEmit)
- [x] Web app builds successfully using shared routes (pnpm --filter web build)

**Acceptance Criteria:**
- FRONT_ROUTES and buildPath are sourced from @routes
- No raw route strings in web app (except re-export file)
- Type safety for dynamic routes

**Rollback Plan:**
- Revert to local routes.ts in apps/web and remove talvra-routes package if necessary.