### PR TITLE
feat(api): T013 - scaffold talvra-api with useAPI and QueryClientProvider

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^20.19.11",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/react-router-dom": "^5.3.3",

--- a/apps/web/src/app/AppProvider.tsx
+++ b/apps/web/src/app/AppProvider.tsx
@@ -1,21 +1,22 @@
 import type { ReactNode } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '@ui';
+import { QueryClientProvider, createQueryClient } from '@api';
 
 interface AppProviderProps {
   children: ReactNode;
 }
 
+const queryClient = createQueryClient();
+
 export default function AppProvider({ children }: AppProviderProps) {
-  // This will be expanded in future tasks with:
-  // - QueryClientProvider (T013)
-  // - Other global providers
-  
   return (
     <ThemeProvider theme={theme}>
-      <div className="app-root" style={{ width: '100%', minHeight: '100vh' }}>
-        {children}
-      </div>
+      <QueryClientProvider client={queryClient}>
+        <div className="app-root" style={{ width: '100%', minHeight: '100vh' }}>
+          {children}
+        </div>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/packages/talvra-api/package.json
+++ b/packages/talvra-api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "talvra-api",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Typed API utilities and useAPI wrapper for Talvra (react-query)",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.52.0",
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  }
+}

--- a/packages/talvra-api/src/index.ts
+++ b/packages/talvra-api/src/index.ts
@@ -1,0 +1,40 @@
+import type { QueryKey, UseQueryOptions } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+
+// Factory to create a QueryClient with sensible defaults
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000, // 1 min
+        gcTime: 5 * 60_000, // 5 mins
+        refetchOnWindowFocus: false,
+        retry: (failureCount) => failureCount < 2,
+      },
+      mutations: {
+        retry: 1,
+      },
+    },
+  })
+}
+
+export { QueryClientProvider }
+
+// Generic typed useAPI wrapper for GET style queries
+export function useAPI<TData = unknown, TError = unknown>(
+  key: QueryKey,
+  fn: () => Promise<TData>,
+  options?: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery<TData, TError>({
+    queryKey: key,
+    queryFn: fn,
+    ...options,
+  })
+}
+
+// Example helper for building keys
+export const qk = {
+  courses: () => ['courses'] as const,
+  course: (courseId: string) => ['courses', courseId] as const,
+}

--- a/packages/talvra-api/tsconfig.json
+++ b/packages/talvra-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.85.5
+        version: 5.85.5(react@19.1.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -33,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.34.0
+      '@types/node':
+        specifier: ^20.19.11
+        version: 20.19.11
       '@types/react':
         specifier: ^19.1.10
         version: 19.1.11
@@ -81,6 +87,22 @@ importers:
       eslint:
         specifier: ^8.45.0
         version: 8.57.1
+
+  packages/talvra-api:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.52.0
+        version: 5.85.5(react@19.1.1)
+      react:
+        specifier: '>=18'
+        version: 19.1.1
+      react-dom:
+        specifier: '>=18'
+        version: 19.1.1(react@19.1.1)
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   packages/talvra-routes:
     devDependencies:
@@ -572,6 +594,14 @@ packages:
     resolution: {integrity: sha512-sq0hHLTgdtwOPDB5SJOuaoHyiP1qSwg+71TQWk8iDS04bW1wIE0oQ6otPiRj2ZvLYNASLMaTp8QRGUVZ+5OL5A==}
     cpu: [x64]
     os: [win32]
+
+  '@tanstack/query-core@5.85.5':
+    resolution: {integrity: sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==}
+
+  '@tanstack/react-query@5.85.5':
+    resolution: {integrity: sha512-/X4EFNcnPiSs8wM2v+b6DqS5mmGeuJQvxBglmDxl6ZQb5V26ouD2SJYAcC3VjbNwqhY2zjxVD15rDA5nGbMn3A==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1854,6 +1884,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.48.0':
     optional: true
+
+  '@tanstack/query-core@5.85.5': {}
+
+  '@tanstack/react-query@5.85.5(react@19.1.1)':
+    dependencies:
+      '@tanstack/query-core': 5.85.5
+      react: 19.1.1
 
   '@types/babel__core@7.20.5':
     dependencies:


### PR DESCRIPTION
**Summary:**
Introduce talvra-api shared package providing a typed useAPI wrapper over @tanstack/react-query and a factory to create a QueryClient. Integrate QueryClientProvider into the web AppProvider.

**Scope:**
- packages/talvra-api: new package (useAPI, createQueryClient, qk helpers)
- apps/web/src/app/AppProvider.tsx: wire QueryClientProvider using @api

**Details:**
- useAPI<T> = typed wrapper around useQuery with explicit key and fn
- createQueryClient() with sensible defaults (staleTime, gcTime, retry, no refetch on focus)
- qk: basic query key helpers for future usage

**Testing:**
- [x] talvra-api type-checks (tsc --noEmit)
- [x] web app builds successfully (pnpm --filter web build)

**Acceptance Criteria:**
- Global QueryClientProvider in AppProvider
- Shared useAPI is available from @api

**Rollback Plan:**
- Remove talvra-api package and revert AppProvider to ThemeProvider only