### PR TITLE
feat(hooks): T014 - scaffold talvra-hooks and fix Vite aliases

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,11 +7,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': '/src',
-      '@ui': '/../../packages/talvra-ui/src',
-      '@hooks': '/../../packages/talvra-hooks/src',
-      '@constants': '/../../packages/talvra-constants/src',
-      '@routes': '/../../packages/talvra-routes/src',
-      '@api': '/../../packages/talvra-api/src',
+      '@ui': '../../packages/talvra-ui/src/index.ts',
+      '@hooks': '../../packages/talvra-hooks/src/index.ts',
+      '@constants': '../../packages/talvra-constants/src/index.ts',
+      '@routes': '../../packages/talvra-routes/src/index.ts',
+      '@api': '../../packages/talvra-api/src/index.ts',
     },
   },
   server: {

--- a/packages/talvra-hooks/package.json
+++ b/packages/talvra-hooks/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "talvra-hooks",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Shared React hooks for Talvra",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.11",
+    "typescript": "~5.8.3"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  }
+}

--- a/packages/talvra-hooks/src/index.ts
+++ b/packages/talvra-hooks/src/index.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react'
+
+// useDebouncedValue: debounces a changing value
+export function useDebouncedValue<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}
+
+// useEvent: stable event handler reference
+export function useEvent<T extends (...args: any[]) => any>(handler: T) {
+  const ref = useRef(handler)
+  ref.current = handler
+  return useRef((...args: Parameters<T>) => ref.current(...args)).current
+}
+
+// useIsMounted: tracks whether component is mounted
+export function useIsMounted() {
+  const ref = useRef(false)
+  useEffect(() => {
+    ref.current = true
+    return () => {
+      ref.current = false
+    }
+  }, [])
+  return ref
+}

--- a/packages/talvra-hooks/tsconfig.json
+++ b/packages/talvra-hooks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,19 @@ importers:
         specifier: ~5.8.3
         version: 5.8.3
 
+  packages/talvra-hooks:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.1.1
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.1.11
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   packages/talvra-routes:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
**Summary:**
Add talvra-hooks shared package with useful React hooks (useDebouncedValue, useEvent, useIsMounted). Fix Vite aliases to point to index.ts for shared packages to avoid EISDIR errors.

**Scope:**
- packages/talvra-hooks: new package with hooks and tsconfig
- apps/web/vite.config.ts: fix aliases to index.ts for @ui, @hooks, @constants, @routes, @api

**Testing:**
- [x] talvra-hooks type-checks
- [x] web build succeeds

**Acceptance Criteria:**
- Shared hooks available via @hooks
- Build remains green

**Rollback Plan:**
- Remove talvra-hooks and revert aliases to previous paths