### PR TITLE
feat(constants): T015 - add talvra-constants and compose app theme with tokens

### DIFF
--- a/frontend/packages/talvra-constants/package.json
+++ b/frontend/packages/talvra-constants/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "talvra-constants",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Design tokens and shared constants for Talvra frontend",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "devDependencies": {
+    "typescript": "~5.8.3"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  }
+}

--- a/frontend/packages/talvra-constants/src/index.ts
+++ b/frontend/packages/talvra-constants/src/index.ts
@@ -1,0 +1,59 @@
+// Design tokens
+export const colors = {
+  white: '#ffffff',
+  gray50: '#f9fafb',
+  gray100: '#f3f4f6',
+  blue50: '#eff6ff',
+  blue600: '#2563eb',
+  slate900: '#0f172a',
+} as const
+
+export const spacing = {
+  none: '0',
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '1rem',
+  lg: '1.5rem',
+  xl: '2rem',
+} as const
+
+export const radii = {
+  none: '0',
+  sm: '0.25rem',
+  md: '0.5rem',
+  lg: '0.75rem',
+} as const
+
+export const shadows = {
+  none: 'none',
+  sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+  md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+} as const
+
+export const zIndex = {
+  base: 0,
+  dropdown: 10,
+  sticky: 20,
+  modal: 40,
+  toast: 50,
+} as const
+
+export const breakpoints = {
+  sm: '640px',
+  md: '768px',
+  lg: '1024px',
+  xl: '1280px',
+} as const
+
+export const transitions = {
+  fast: '150ms ease-in-out',
+  normal: '250ms ease-in-out',
+  slow: '400ms ease-in-out',
+} as const
+
+// App-level constants
+export const APP_NAME = 'Talvra'
+export const FEATURE_FLAGS = {
+  demoMode: false,
+} as const

--- a/frontend/packages/talvra-constants/tsconfig.json
+++ b/frontend/packages/talvra-constants/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/packages/talvra-ui/package.json
+++ b/frontend/packages/talvra-ui/package.json
@@ -11,6 +11,7 @@
     "src"
   ],
   "scripts": {
+    "type-check": "tsc --noEmit",
     "build": "echo 'Build placeholder - will be added in future'",
     "dev": "echo 'Dev mode placeholder'",
     "lint": "eslint src --ext .ts,.tsx"
@@ -24,7 +25,8 @@
     "react": "^19.1.1",
     "eslint": "^8.45.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0"
+    "@typescript-eslint/parser": "^6.0.0",
+    "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/frontend/packages/talvra-ui/src/Text.tsx
+++ b/frontend/packages/talvra-ui/src/Text.tsx
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 
+import type React from 'react';
+
 export interface TextProps {
   variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'body' | 'small' | 'caption';
   color?: 'gray-900' | 'gray-700' | 'gray-500' | 'blue-600' | 'red-600';
   weight?: 'normal' | 'medium' | 'semibold' | 'bold';
   align?: 'left' | 'center' | 'right';
-  as?: keyof JSX.IntrinsicElements;
+  as?: keyof React.JSX.IntrinsicElements;
 }
 
 const variantStyles = {

--- a/frontend/packages/talvra-ui/tsconfig.json
+++ b/frontend/packages/talvra-ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "composite": true,
+    "baseUrl": ".",
+    "types": ["react"],
+    "paths": {
+      "@constants": ["../talvra-constants/src"],
+      "@constants/*": ["../talvra-constants/src/*"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -34,6 +34,12 @@ importers:
         specifier: ~5.8.3
         version: 5.8.3
 
+  packages/talvra-constants:
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   packages/talvra-hooks:
     dependencies:
       react:
@@ -80,6 +86,9 @@ importers:
       react:
         specifier: ^19.1.1
         version: 19.1.1
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   web:
     dependencies:

--- a/frontend/web/src/app/AppProvider.tsx
+++ b/frontend/web/src/app/AppProvider.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { theme } from '@ui';
+import { theme as uiTheme } from '@ui';
+import { colors as tokens } from '@constants';
 import { QueryClientProvider, createQueryClient } from '@api';
 
 interface AppProviderProps {
@@ -9,9 +10,27 @@ interface AppProviderProps {
 
 const queryClient = createQueryClient();
 
+// Compose app theme from UI theme + shared tokens
+const appTheme = {
+  ...uiTheme,
+  colors: {
+    ...uiTheme.colors,
+    primary: {
+      ...uiTheme.colors.primary,
+      50: tokens.blue50,
+      600: tokens.blue600,
+    },
+    gray: {
+      ...uiTheme.colors.gray,
+      50: tokens.gray50,
+      100: tokens.gray100,
+    },
+  },
+};
+
 export default function AppProvider({ children }: AppProviderProps) {
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={appTheme}>
       <QueryClientProvider client={queryClient}>
         <div className="app-root" style={{ width: '100%', minHeight: '100vh' }}>
           {children}

--- a/frontend/web/tsconfig.app.json
+++ b/frontend/web/tsconfig.app.json
@@ -34,7 +34,9 @@
       "@routes": ["../packages/talvra-routes/src"],
       "@routes/*": ["../packages/talvra-routes/src/*"],
       "@api": ["../packages/talvra-api/src"],
-      "@api/*": ["../packages/talvra-api/src/*"]
+      "@api/*": ["../packages/talvra-api/src/*"],
+      "@constants": ["../packages/talvra-constants/src"],
+      "@constants/*": ["../packages/talvra-constants/src/*"]
     }
   },
   "include": ["src"]

--- a/frontend/web/tsconfig.json
+++ b/frontend/web/tsconfig.json
@@ -2,6 +2,11 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../packages/talvra-constants" },
+    { "path": "../packages/talvra-ui" },
+    { "path": "../packages/talvra-api" },
+    { "path": "../packages/talvra-hooks" },
+    { "path": "../packages/talvra-routes" }
   ]
 }

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       '@hooks': path.resolve(__dirname, '../packages/talvra-hooks/src'),
       '@routes': path.resolve(__dirname, '../packages/talvra-routes/src'),
       '@api': path.resolve(__dirname, '../packages/talvra-api/src'),
+      '@constants': path.resolve(__dirname, '../packages/talvra-constants/src'),
     },
   },
   server: {


### PR DESCRIPTION
**Summary**
Create shared design tokens and app constants package (talvra-constants). Integrate tokens at the app layer by composing the @ui theme with @constants in AppProvider, avoiding cross-package cycles.

**Changes**
- frontend/packages/talvra-constants: export colors, spacing, radii, shadows, zIndex, breakpoints, transitions, APP_NAME, FEATURE_FLAGS
- frontend/web: compose theme in AppProvider; add @constants to tsconfig + Vite aliases
- frontend/packages/talvra-ui: add tsconfig (composite + React types) for package type-check support

**Why**
- Establish a single source of truth for design tokens while keeping UI primitives stable
- Composition at the app layer lets us iterate without introducing cycles across packages

**Testing**
- Build passes: No projects matched the filters "/Users/oluwatobiolajide/Desktop/Code/talvra/frontend" in "/Users/oluwatobiolajide/Desktop/Code/talvra/frontend"

> web@0.0.0 build /Users/oluwatobiolajide/Desktop/Code/talvra/frontend/web
> tsc -b && vite build

vite v7.1.3 building for production...
transforming...
✓ 117 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.46 kB │ gzip:   0.30 kB
dist/assets/index-k70VBc59.css    0.92 kB │ gzip:   0.49 kB
dist/assets/index-DkoqPPGj.js   322.15 kB │ gzip: 104.32 kB
✓ built in 449ms

**Follow-ups**
- Gradually migrate UI primitives to consume theme values only (optional)
- Expose more tokens (typography scale, spacing scale) to reduce literal values over time