### PR TITLE
feat(gateway): T021 - Fastify skeleton with /health and request id

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "api-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Talvra API Gateway skeleton (Fastify)",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "fastify": "^4.26.2"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "tsx": "^4.20.4"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -1,0 +1,32 @@
+import Fastify from 'fastify'
+import { randomUUID } from 'node:crypto'
+
+const app = Fastify({ logger: true })
+
+// Request ID hook - prefer incoming header, fallback to Fastify's req.id
+app.addHook('onRequest', async (req, reply) => {
+  const incoming = req.headers['x-request-id']
+  const reqId = typeof incoming === 'string' ? incoming : req.id
+  reply.header('x-request-id', reqId)
+})
+
+// Root route (smoke)
+app.get('/', async () => {
+  return { ok: true }
+})
+
+// Health endpoint - echo request id
+app.get('/health', async (req, reply) => {
+  const header = reply.getHeader('x-request-id')
+  const requestId = (typeof header === 'string' ? header : undefined) ?? req.id ?? randomUUID()
+  return { ok: true, request_id: requestId }
+})
+
+const port = Number(process.env.PORT ?? 3001)
+app
+  .listen({ port, host: '0.0.0.0' })
+  .then(() => app.log.info(`API Gateway listening on :${port}`))
+  .catch((err) => {
+    app.log.error(err)
+    process.exit(1)
+  })

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../frontend/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": false,
+    "noEmit": false,
+    "module": "ESNext",
+    "target": "ES2022",
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
**Summary**\nIntroduce API Gateway skeleton with Fastify. Adds request id echo and a /health endpoint.\n\n**Changes**\n- services/api-gateway: Fastify app, dev/build scripts, TS config\n\n**Endpoints**\n- GET /           -> { ok: true }\n- GET /health     -> { ok: true, request_id } (echoes x-request-id or uses req.id)\n\n**Dev**\n\n\n**Build**\n\n\n**Notes**\n- Uses Fastify logger and sets x-request-id header from incoming or Fastify's req.id\n- No lint/type errors in the service; TS build succeeds