### PR TITLE
backend/auth cookie fix

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -10,7 +10,8 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "fastify": "^4.26.2"
+    "fastify": "^5.0.0",
+    "@fastify/http-proxy": "^10.0.2"
   },
   "devDependencies": {
     "typescript": "~5.8.3",

--- a/services/auth-service/package.json
+++ b/services/auth-service/package.json
@@ -10,12 +10,13 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@fastify/cookie": "^9.3.1",
+    "@fastify/cookie": "^9.4.0",
     "argon2": "^0.41.1",
-    "fastify": "^4.26.2",
+    "fastify": "^4.29.1",
     "pg": "^8.12.0"
   },
   "devDependencies": {
+    "@types/node": "^20.14.2",
     "@types/pg": "^8.15.5",
     "tsx": "^4.20.4",
     "typescript": "~5.8.3"

--- a/services/auth-service/src/index.ts
+++ b/services/auth-service/src/index.ts
@@ -8,11 +8,7 @@ import { URLSearchParams } from 'node:url'
 const app = Fastify({ logger: true })
 
 // Env
-const DB_USER = process.env.POSTGRES_USER ?? 'talvra'
-const DB_PASSWORD = process.env.POSTGRES_PASSWORD ?? 'talvra'
-const DB_NAME = process.env.POSTGRES_DB ?? 'talvra'
-const DB_PORT = Number(process.env.POSTGRES_PORT ?? 5432)
-const DB_HOST = process.env.POSTGRES_HOST ?? '127.0.0.1'
+const DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://talvra:talvra@localhost:5432/talvra'
 const AUTH_HOST = process.env.AUTH_SERVICE_HOST ?? '0.0.0.0'
 const AUTH_PORT = Number(process.env.AUTH_SERVICE_PORT ?? 4001)
 const SESSION_COOKIE = process.env.AUTH_SESSION_COOKIE ?? 'talvra.sid'
@@ -29,7 +25,7 @@ function b64url(buf: Buffer) {
 }
 
 // PG
-const pool = new Pool({ user: DB_USER, password: DB_PASSWORD, database: DB_NAME, port: DB_PORT, host: DB_HOST })
+const pool = new Pool({ connectionString: DATABASE_URL })
 
 async function bootstrapDb() {
   await pool.query(`
@@ -50,7 +46,7 @@ async function bootstrapDb() {
   `)
 }
 
-app.register(cookie, { secret: process.env.AUTH_COOKIE_SECRET ?? 'dev-secret', hook: 'onRequest' })
+await app.register(cookie, { secret: process.env.AUTH_COOKIE_SECRET ?? 'dev-secret' })
 
 app.post('/auth/signup', async (req, reply) => {
   const body = (req.body ?? {}) as { email?: string; password?: string }

--- a/services/auth-service/src/index.ts
+++ b/services/auth-service/src/index.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify'
 import cookie from '@fastify/cookie'
+import '@fastify/cookie'
 import { Pool } from 'pg'
 import argon2 from 'argon2'
 import { randomBytes, createHash } from 'node:crypto'
@@ -46,7 +47,7 @@ async function bootstrapDb() {
   `)
 }
 
-await app.register(cookie, { secret: process.env.AUTH_COOKIE_SECRET ?? 'dev-secret' })
+await app.register(cookie as any, { secret: process.env.AUTH_COOKIE_SECRET ?? 'dev-secret' })
 
 app.post('/auth/signup', async (req, reply) => {
   const body = (req.body ?? {}) as { email?: string; password?: string }

--- a/services/auth-service/src/types/fastify-cookie.d.ts
+++ b/services/auth-service/src/types/fastify-cookie.d.ts
@@ -1,0 +1,15 @@
+// Local augmentation to ensure Fastify sees cookie helpers in this service's TS build
+// This mirrors the shape provided by @fastify/cookie for compile-time only.
+import 'fastify'
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    cookies?: Record<string, string>
+    unsignCookie?: (value: string) => { valid: boolean; value: string | null; renewed?: boolean }
+  }
+  interface FastifyReply {
+    setCookie: (name: string, value: string, options?: any) => this
+    clearCookie: (name: string, options?: any) => this
+  }
+}
+

--- a/services/auth-service/tsconfig.json
+++ b/services/auth-service/tsconfig.json
@@ -1,13 +1,18 @@
 {
-  "extends": "../../frontend/tsconfig.base.json",
   "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
     "rootDir": "src",
     "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
     "noEmit": false,
     "declaration": false,
-    "module": "ESNext",
-    "target": "ES2022",
-    "allowImportingTsExtensions": false
+    "types": ["node", "@fastify/cookie"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
- **feat(api): T013 - scaffold talvra-api with useAPI and QueryClientProvider\n\n**Summary:** Introduce talvra-api shared package providing a typed useAPI wrapper over @tanstack/react-query and a factory to create a QueryClient. Integrate QueryClientProvider into the web AppProvider.\n\n**Scope:**\n- packages/talvra-api: new package (useAPI, createQueryClient, qk helpers)\n- apps/web/src/app/AppProvider.tsx: wire QueryClientProvider using @api\n\n**Testing:**\n- ✓ talvra-api type-checks (tsc --noEmit)\n- ✓ web app builds successfully\n\n**Rollback Plan:**\n- Remove talvra-api package and revert AppProvider to ThemeProvider only**
- **feat(hooks): T014 - scaffold talvra-hooks and fix Vite aliases to shared packages\n\n**Summary:** Add talvra-hooks shared package with useful React hooks (useDebouncedValue, useEvent, useIsMounted). Fix Vite aliases to point to index.ts for shared packages to avoid EISDIR errors.\n\n**Scope:**\n- packages/talvra-hooks: new package with hooks and tsconfig\n- apps/web/vite.config.ts: fix aliases to index.ts for @ui, @hooks, @constants, @routes, @api\n\n**Testing:**\n- ✓ talvra-hooks type-checks\n- ✓ web build succeeds with new aliases\n\n**Rollback Plan:**\n- Remove talvra-hooks and revert aliases to previous paths**
- **docs(tasks): update Phase 1 statuses for T011–T013 and align branches/paths**
- **chore(web): incorporate local tweaks to tsconfig and vite aliases**
- **chore(repo): move frontend into nested workspace (frontend/) and update configs\n\n- git mv apps/* -> frontend/web, packages/* -> frontend/packages, tsconfig.base.json -> frontend/tsconfig.base.json\n- add frontend/pnpm-workspace.yaml; update CI to run in nested workspace\n- fix path aliases in frontend/web tsconfig + Vite\n- verify build: pnpm -C frontend --filter web build**
- **ci(frontend): update lockfile after workspace split to fix frozen-lockfile in CI**
- **ci: install root dev deps so tsx is available for process validation**
- **feat(constants): T015 - add talvra-constants and integrate tokens into app theme\n\n**Summary:**\nAdd shared design tokens and app constants in frontend/packages/talvra-constants. Integrate tokens into the app theme by composing @ui theme with @constants in AppProvider.\n\n**Scope:**\n- frontend/packages/talvra-constants: colors, spacing, radii, shadows, zIndex, breakpoints, transitions, APP_NAME, FEATURE_FLAGS\n- frontend/web: compose app theme from tokens + ui theme; add @constants alias to Vite/TS\n- frontend/packages/talvra-ui: tsconfig for type-checking (React types)\n\n**Testing:**\n- pnpm -C frontend --filter web build passes\n\n**Notes:**\n- UI theme kept as source-of-truth and composed at app layer to avoid cyclic deps.\n- Future: gradually migrate UI primitives to reference theme values exclusively.**
- **docs(tasks): mark T014 and T015 completed and document branches/paths**
- **infra(compose): T020 - add docker-compose for Postgres, Redis, Azurite and README quickstart**
- **feat(gateway): T021 - Fastify skeleton with /health and request id, buildable TS config**
- **chore(gateway): use API_GATEWAY_HOST and API_GATEWAY_PORT env keys; add to .env.example**
- **feat(auth): T022 - Auth service skeleton (Fastify + Postgres), signup/login/session endpoints**
- **feat(auth): add Google OAuth (OIDC) login/link restricted to @morgan.edu; env keys; keep manual Canvas token approach**
- **feat(gateway): proxy /api/auth/* to auth-service; align fastify v5**
- **auth-service: fix cookie plugin registration (remove unsupported hook) and switch to DATABASE_URL; keep fastify/@fastify/cookie versions unchanged**
- **auth-service: switch to DATABASE_URL, remove cookie hook, fix Fastify cookie types with tsconfig NodeNext + @types/node and local augmentation; pin fastify@^4.29.1 and @fastify/cookie@^9.4.0**
