### PR TITLE
chore(gateway): allow PUT/DELETE in CORS for token endpoints

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -17,7 +17,7 @@ const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? 'http://localhost:5173'
 await app.register(cors as any, {
   origin: FRONTEND_ORIGIN,
   credentials: true,
-  methods: ['GET', 'POST', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['content-type', 'x-request-id']
 })
 


### PR DESCRIPTION
Cherry-pick CORS methods fix from canvas integration branch to ensure frontend can call:

- PUT /auth/canvas/token
- DELETE /auth/canvas/token

Also keeps other CORS settings unchanged.