### PR TITLE
feat(web): T042 document view page wired to ingestion outputs

### DIFF
--- a/frontend/web/src/Areas/Documents/Detail.tsx
+++ b/frontend/web/src/Areas/Documents/Detail.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink } from '@ui';
+import { useParams } from 'react-router-dom';
+
+const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return await res.text();
+}
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return (await res.json()) as T;
+}
+
+export default function DocumentDetailArea() {
+  const { documentId } = useParams<{ documentId: string }>();
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [structure, setStructure] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const resultUrl = useMemo(() => `${API_BASE}/api/ingestion/result/${encodeURIComponent(documentId || '')}`, [documentId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setError(null);
+      setMarkdown(null);
+      setStructure(null);
+      try {
+        const res = await fetchJSON<{ ok: true; outputs: { markdown: string; structure: string } }>(resultUrl);
+        const [md, st] = await Promise.all([
+          fetchText(`${API_BASE}${res.outputs.markdown}`),
+          fetchJSON(`${API_BASE}${res.outputs.structure}`),
+        ]);
+        if (!cancelled) {
+          setMarkdown(md);
+          setStructure(st);
+        }
+      } catch (e: any) {
+        if (!cancelled) setError(String(e?.message || e));
+      }
+    }
+    if (documentId) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId, resultUrl]);
+
+  return (
+    <TalvraSurface>
+      <TalvraStack>
+        <TalvraText as="h1">Document: {documentId}</TalvraText>
+        {error && <TalvraText>Error: {error}</TalvraText>}
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Structure</TalvraText>
+            <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto', background: '#f8fafc', padding: 12, borderRadius: 8 }}>
+              {structure ? JSON.stringify(structure, null, 2) : 'Loading...'}
+            </pre>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Markdown</TalvraText>
+            <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto', background: '#f8fafc', padding: 12, borderRadius: 8 }}>
+              {markdown ?? 'Loading...'}
+            </pre>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraLink href="/documents">Back to Documents</TalvraLink>
+      </TalvraStack>
+    </TalvraSurface>
+  );
+}
+

--- a/frontend/web/src/Areas/Documents/index.tsx
+++ b/frontend/web/src/Areas/Documents/index.tsx
@@ -1,0 +1,44 @@
+import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard } from '@ui';
+import { FRONT_ROUTES, buildPath } from '@/app/routes';
+
+export default function DocumentsArea() {
+  return (
+    <TalvraSurface>
+      <TalvraStack>
+        <TalvraText as="h1">Documents</TalvraText>
+        <TalvraText>After you start ingestion, processed documents will appear here.</TalvraText>
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">How to process a file</TalvraText>
+            <TalvraText>
+              1) Copy a PDF/DOCX into the ingestion container at /tmp/file.pdf
+            </TalvraText>
+            <TalvraText>
+              2) POST /api/ingestion/start with {{ file:"/tmp/file.pdf", doc_id:"mydoc" }}
+            </TalvraText>
+            <TalvraText>
+              3) Open the detail page at /documents/mydoc to view outputs
+            </TalvraText>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraStack>
+          <TalvraText as="h2">Navigation</TalvraText>
+          <TalvraStack>
+            <TalvraLink href={buildPath(FRONT_ROUTES.ADMIN)}>
+              {FRONT_ROUTES.ADMIN.name}
+            </TalvraLink>
+            <TalvraLink href={buildPath(FRONT_ROUTES.COURSES)}>
+              {FRONT_ROUTES.COURSES.name}
+            </TalvraLink>
+            <TalvraLink href={buildPath(FRONT_ROUTES.SETTINGS)}>
+              {FRONT_ROUTES.SETTINGS.name}
+            </TalvraLink>
+          </TalvraStack>
+        </TalvraStack>
+      </TalvraStack>
+    </TalvraSurface>
+  );
+}
+

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -57,6 +57,18 @@ await app.register(httpProxy as any, {
   rewritePrefix: '/canvas'
 })
 
+// Proxy to ingestion-service
+const INGEST_UPSTREAM_HOST = process.env.INGESTION_SERVICE_HOST ?? 'ingestion-service'
+const INGEST_UPSTREAM_PORT = Number(process.env.INGESTION_SERVICE_PORT ?? 4010)
+const INGEST_UPSTREAM_DEFAULT = `http://${INGEST_UPSTREAM_HOST}:${INGEST_UPSTREAM_PORT}`
+const INGEST_UPSTREAM = process.env.INGESTION_SERVICE_URL ?? INGEST_UPSTREAM_DEFAULT
+
+await app.register(httpProxy as any, {
+  upstream: INGEST_UPSTREAM,
+  prefix: '/api/ingestion',
+  rewritePrefix: '/ingestion'
+})
+
 const port = Number(process.env.API_GATEWAY_PORT ?? 3001)
 const host = String(process.env.API_GATEWAY_HOST ?? '0.0.0.0')
 app


### PR DESCRIPTION
This implements T042.

- Gateway: adds /api/ingestion proxy to ingestion-service
- Ingestion-service: serves markdown and structure blobs; result endpoint returns fetchable URLs
- Frontend: adds Documents landing and Document detail routes/pages; detail page fetches and renders markdown + structure

How to test:
1) docker compose -f infra/docker-compose.yml up -d --build redis api-gateway ingestion-service web
2) docker cp /path/to/test.pdf talvra_ingestion_service:/tmp/test.pdf
3) curl -sS -X POST http://localhost:3001/api/ingestion/start -H 'content-type: application/json' -d '{file:/tmp/test.pdf,doc_id:test}'
4) Visit http://localhost:5173/documents/test

Notes:
- Outputs currently served from local disk via ingestion-service as a blob mock.
- Follow-ups: list documents from storage/db once added.