### PR TITLE
feat(ingestion): T043 pluggable storage (LocalFs + Azure/Azurite)

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -367,6 +367,28 @@
             "title": "feat(web) document view screen",
             "body": "What: page and routes."
           },
+          "completed": true
+        },
+        {
+          "id": "T043",
+          "title": "Ingestion storage provider (LocalFs + Azure Blob/Azurite)",
+          "branch": "backend/ingestion-storage",
+          "paths": ["services/ingestion-service/**", "infra/.env.example"],
+          "steps": [
+            "Add StorageProvider interface and LocalFs/Azure adapters",
+            "Write originals and artifacts to provider",
+            "Return gateway/SAS URLs from result endpoint",
+            "Document Azurite/Azure env in infra/.env.example"
+          ],
+          "run": ["docker compose -f infra/docker-compose.yml up -d --build ingestion-service"],
+          "acceptance": [
+            "Extraction writes blobs to Azurite when configured, LocalFs otherwise",
+            "/api/ingestion/result/:doc_id returns fetchable URLs"
+          ],
+          "pr": {
+            "title": "feat(ingestion): T043 pluggable storage (LocalFs + Azure Blob/Azurite)",
+            "body": "What: storage abstraction and Azure adapter. How: env selects provider. Tests: Azurite run and fetch URLs."
+          },
           "completed": false
         }
       ]

--- a/frontend/web/src/Areas/Documents/Detail.tsx
+++ b/frontend/web/src/Areas/Documents/Detail.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink } from '@ui';
+import { useParams } from 'react-router-dom';
+
+const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return await res.text();
+}
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return (await res.json()) as T;
+}
+
+export default function DocumentDetailArea() {
+  const { documentId } = useParams<{ documentId: string }>();
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [structure, setStructure] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const resultUrl = useMemo(() => `${API_BASE}/api/ingestion/result/${encodeURIComponent(documentId || '')}`, [documentId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setError(null);
+      setMarkdown(null);
+      setStructure(null);
+      try {
+        const res = await fetchJSON<{ ok: true; outputs: { markdown: string; structure: string } }>(resultUrl);
+        const [md, st] = await Promise.all([
+          fetchText(`${API_BASE}${res.outputs.markdown}`),
+          fetchJSON(`${API_BASE}${res.outputs.structure}`),
+        ]);
+        if (!cancelled) {
+          setMarkdown(md);
+          setStructure(st);
+        }
+      } catch (e: any) {
+        if (!cancelled) setError(String(e?.message || e));
+      }
+    }
+    if (documentId) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId, resultUrl]);
+
+  return (
+    <TalvraSurface>
+      <TalvraStack>
+        <TalvraText as="h1">Document: {documentId}</TalvraText>
+        {error && <TalvraText>Error: {error}</TalvraText>}
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Structure</TalvraText>
+            <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto', background: '#f8fafc', padding: 12, borderRadius: 8 }}>
+              {structure ? JSON.stringify(structure, null, 2) : 'Loading...'}
+            </pre>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Markdown</TalvraText>
+            <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto', background: '#f8fafc', padding: 12, borderRadius: 8 }}>
+              {markdown ?? 'Loading...'}
+            </pre>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraLink href="/documents">Back to Documents</TalvraLink>
+      </TalvraStack>
+    </TalvraSurface>
+  );
+}
+

--- a/frontend/web/src/Areas/Documents/index.tsx
+++ b/frontend/web/src/Areas/Documents/index.tsx
@@ -1,0 +1,44 @@
+import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard } from '@ui';
+import { FRONT_ROUTES, buildPath } from '@/app/routes';
+
+export default function DocumentsArea() {
+  return (
+    <TalvraSurface>
+      <TalvraStack>
+        <TalvraText as="h1">Documents</TalvraText>
+        <TalvraText>After you start ingestion, processed documents will appear here.</TalvraText>
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">How to process a file</TalvraText>
+            <TalvraText>
+              1) Copy a PDF/DOCX into the ingestion container at /tmp/file.pdf
+            </TalvraText>
+            <TalvraText>
+              2) POST /api/ingestion/start with {{ file:"/tmp/file.pdf", doc_id:"mydoc" }}
+            </TalvraText>
+            <TalvraText>
+              3) Open the detail page at /documents/mydoc to view outputs
+            </TalvraText>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraStack>
+          <TalvraText as="h2">Navigation</TalvraText>
+          <TalvraStack>
+            <TalvraLink href={buildPath(FRONT_ROUTES.ADMIN)}>
+              {FRONT_ROUTES.ADMIN.name}
+            </TalvraLink>
+            <TalvraLink href={buildPath(FRONT_ROUTES.COURSES)}>
+              {FRONT_ROUTES.COURSES.name}
+            </TalvraLink>
+            <TalvraLink href={buildPath(FRONT_ROUTES.SETTINGS)}>
+              {FRONT_ROUTES.SETTINGS.name}
+            </TalvraLink>
+          </TalvraStack>
+        </TalvraStack>
+      </TalvraStack>
+    </TalvraSurface>
+  );
+}
+

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,58 @@
+# Postgres
+POSTGRES_USER=talvra
+POSTGRES_PASSWORD=talvra
+POSTGRES_DB=talvra
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://talvra:talvra@localhost:5432/talvra
+
+# Redis
+REDIS_PORT=6379
+
+# Azurite (Azure Blob emulator)
+AZURITE_BLOB_PORT=10000
+
+# API Gateway
+API_GATEWAY_HOST=0.0.0.0
+API_GATEWAY_PORT=3001
+FRONTEND_ORIGIN=http://localhost:5173
+
+# Services
+AUTH_SERVICE_HOST=0.0.0.0
+AUTH_SERVICE_PORT=4001
+AUTH_SERVICE_URL=http://localhost:4001
+CANVAS_SERVICE_HOST=0.0.0.0
+CANVAS_SERVICE_PORT=4002
+#mode can be "development" or "production"
+MODE=development
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:3001/api/auth/google/callback
+AUTH_GOOGLE_SCOPES=openid email profile
+AUTH_GOOGLE_ALLOWED_HD=morgan.edu
+
+# Canvas (token verification only)
+# Base URL for your institution's Canvas instance (e.g., https://morganstate.instructure.com)
+CANVAS_BASE_URL=
+# Symmetric key used to encrypt Canvas tokens at rest (keep secret in real envs)
+CANVAS_TOKEN_SECRET=dev-canvas-secret
+
+# Ingestion service
+# Host/port
+INGESTION_SERVICE_HOST=0.0.0.0
+INGESTION_SERVICE_PORT=4010
+# Redis connection and stream name used by ingestion
+REDIS_URL=redis://localhost:6379
+INGEST_STREAM=ingest.request
+# Storage provider: 'local' or 'azure'
+INGEST_STORAGE_PROVIDER=local
+# Local output directory where extracted files are written (mocking blob storage)
+INGEST_OUTPUT_DIR=./services/ingestion-service/out
+# Azure/Azurite storage settings
+# For Azurite (dev), use the emulator connection string below and container name
+#AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true
+#AZURE_STORAGE_CONTAINER=talvra
+# For real Azure (prod), set the real connection string and preferred container
+#AZURE_STORAGE_CONNECTION_STRING=
+#AZURE_STORAGE_CONTAINER=
+

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -57,6 +57,18 @@ await app.register(httpProxy as any, {
   rewritePrefix: '/canvas'
 })
 
+// Proxy to ingestion-service
+const INGEST_UPSTREAM_HOST = process.env.INGESTION_SERVICE_HOST ?? 'ingestion-service'
+const INGEST_UPSTREAM_PORT = Number(process.env.INGESTION_SERVICE_PORT ?? 4010)
+const INGEST_UPSTREAM_DEFAULT = `http://${INGEST_UPSTREAM_HOST}:${INGEST_UPSTREAM_PORT}`
+const INGEST_UPSTREAM = process.env.INGESTION_SERVICE_URL ?? INGEST_UPSTREAM_DEFAULT
+
+await app.register(httpProxy as any, {
+  upstream: INGEST_UPSTREAM,
+  prefix: '/api/ingestion',
+  rewritePrefix: '/ingestion'
+})
+
 const port = Number(process.env.API_GATEWAY_PORT ?? 3001)
 const host = String(process.env.API_GATEWAY_HOST ?? '0.0.0.0')
 app

--- a/services/ingestion-service/package.json
+++ b/services/ingestion-service/package.json
@@ -12,7 +12,8 @@
     "fastify": "^4.29.1",
     "ioredis": "^5.4.1",
     "mammoth": "^1.6.0",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "@azure/storage-blob": "^12.23.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.11",

--- a/services/ingestion-service/src/index.ts
+++ b/services/ingestion-service/src/index.ts
@@ -3,6 +3,9 @@ import Redis from 'ioredis'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import mammoth from 'mammoth'
+import { LocalFsProvider } from './storage/local'
+import { AzureBlobProvider } from './storage/azure'
+import type { StorageProvider } from './storage/provider'
 
 const app = Fastify({ logger: { level: 'info' } })
 
@@ -12,6 +15,19 @@ const PORT = Number(process.env.INGESTION_SERVICE_PORT ?? 4010)
 const REDIS_URL = process.env.REDIS_URL ?? 'redis://redis:6379'
 const STREAM = process.env.INGEST_STREAM ?? 'ingest.request'
 const OUTPUT_DIR = process.env.INGEST_OUTPUT_DIR ?? path.resolve(process.cwd(), 'out')
+const STORAGE_PROVIDER = process.env.INGEST_STORAGE_PROVIDER ?? 'local'
+const AZURE_CS = process.env.AZURE_STORAGE_CONNECTION_STRING
+const AZURE_CONTAINER = process.env.AZURE_STORAGE_CONTAINER ?? 'talvra'
+
+let storage: StorageProvider
+if (STORAGE_PROVIDER === 'azure') {
+  if (!AZURE_CS) {
+    throw new Error('INGEST_STORAGE_PROVIDER=azure but AZURE_STORAGE_CONNECTION_STRING is missing')
+  }
+  storage = new AzureBlobProvider(AZURE_CS, AZURE_CONTAINER)
+} else {
+  storage = new LocalFsProvider(OUTPUT_DIR)
+}
 
 const redis = new Redis(REDIS_URL)
 
@@ -60,15 +76,14 @@ app.post('/ingestion/start', async (req, reply) => {
   try {
     const { markdown, structure } = await extractToMarkdown(body.file)
 
-    // Write outputs to local out dir (mocking blob storage for now)
-    await fs.mkdir(OUTPUT_DIR, { recursive: true })
-    const mdPath = path.join(OUTPUT_DIR, `${docId}.md`)
-    const structPath = path.join(OUTPUT_DIR, `${docId}.structure.json`)
-    await fs.writeFile(mdPath, markdown, 'utf8')
-    await fs.writeFile(structPath, JSON.stringify(structure, null, 2), 'utf8')
+    // Persist outputs via storage provider
+    const mdKey = `artifacts/${docId}/content.md`
+    const structKey = `artifacts/${docId}/structure.json`
+    await storage.put(mdKey, markdown, 'text/markdown; charset=utf-8')
+    await storage.put(structKey, JSON.stringify(structure, null, 2), 'application/json; charset=utf-8')
 
-    // Enqueue event
-    const msg = { request_id: id, ts: new Date().toISOString(), doc_id: docId, outputs: { markdown: mdPath, structure: structPath } }
+    // Enqueue event with logical keys
+    const msg = { request_id: id, ts: new Date().toISOString(), doc_id: docId, outputs: { markdown: mdKey, structure: structKey } }
     await redis.xadd(STREAM, '*', 'json', JSON.stringify(msg))
 
     return { ok: true, doc_id: docId, outputs: msg.outputs }
@@ -81,11 +96,11 @@ app.post('/ingestion/start', async (req, reply) => {
 app.get('/ingestion/result/:doc_id', async (req, reply) => {
   const params = req.params as { doc_id: string }
   const docId = params.doc_id
-  const mdPath = path.join(OUTPUT_DIR, `${docId}.md`)
-  const structPath = path.join(OUTPUT_DIR, `${docId}.structure.json`)
+  const mdKey = `artifacts/${docId}/content.md`
+  const structKey = `artifacts/${docId}/structure.json`
   try {
-    const existsMd = await fs.access(mdPath).then(() => true).catch(() => false)
-    const existsStruct = await fs.access(structPath).then(() => true).catch(() => false)
+    const existsMd = await storage.exists(mdKey)
+    const existsStruct = await storage.exists(structKey)
     if (!existsMd || !existsStruct) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'results not found' } })
     // Expose fetchable URLs via gateway path (proxy maps /api/ingestion -> /ingestion)
     const base = '/api/ingestion'
@@ -102,13 +117,13 @@ app.get('/ingestion/result/:doc_id', async (req, reply) => {
 app.get('/ingestion/blob/:doc_id/markdown', async (req, reply) => {
   const params = req.params as { doc_id: string }
   const docId = params.doc_id
-  const mdPath = path.join(OUTPUT_DIR, `${docId}.md`)
+  const mdKey = `artifacts/${docId}/content.md`
   try {
-    const content = await fs.readFile(mdPath, 'utf8')
+    const { body } = await storage.get(mdKey)
     reply.header('content-type', 'text/markdown; charset=utf-8')
-    return content
+    return body.toString('utf8')
   } catch (e: any) {
-    if ((e as any)?.code === 'ENOENT') return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'markdown not found' } })
+    if ((e as any)?.statusCode === 404 || (e as any)?.code === 'ENOENT') return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'markdown not found' } })
     return reply.code(500).send({ error: { code: 'INTERNAL', message: String(e?.message || e) } })
   }
 })
@@ -117,14 +132,14 @@ app.get('/ingestion/blob/:doc_id/markdown', async (req, reply) => {
 app.get('/ingestion/blob/:doc_id/structure', async (req, reply) => {
   const params = req.params as { doc_id: string }
   const docId = params.doc_id
-  const structPath = path.join(OUTPUT_DIR, `${docId}.structure.json`)
+  const structKey = `artifacts/${docId}/structure.json`
   try {
-    const buf = await fs.readFile(structPath, 'utf8')
-    const json = JSON.parse(buf)
+    const { body } = await storage.get(structKey)
+    const json = JSON.parse(body.toString('utf8'))
     reply.header('content-type', 'application/json; charset=utf-8')
     return json
   } catch (e: any) {
-    if ((e as any)?.code === 'ENOENT') return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'structure not found' } })
+    if ((e as any)?.statusCode === 404 || (e as any)?.code === 'ENOENT') return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'structure not found' } })
     return reply.code(500).send({ error: { code: 'INTERNAL', message: String(e?.message || e) } })
   }
 })

--- a/services/ingestion-service/src/storage/azure.ts
+++ b/services/ingestion-service/src/storage/azure.ts
@@ -1,0 +1,51 @@
+import { BlobServiceClient } from '@azure/storage-blob'
+import type { StorageProvider, BlobPointer } from './provider'
+
+export class AzureBlobProvider implements StorageProvider {
+  private containerName: string
+  private client: BlobServiceClient
+
+  constructor(connectionString: string, containerName: string) {
+    this.client = BlobServiceClient.fromConnectionString(connectionString)
+    this.containerName = containerName
+  }
+
+  private async getContainer() {
+    const container = this.client.getContainerClient(this.containerName)
+    await container.createIfNotExists()
+    return container
+  }
+
+  async put(p: string, content: Buffer | string, contentType?: string): Promise<BlobPointer> {
+    const container = await this.getContainer()
+    const block = container.getBlockBlobClient(p)
+    const data = typeof content === 'string' ? Buffer.from(content) : content
+    await block.uploadData(data, { blobHTTPHeaders: { blobContentType: contentType } })
+    return { container: this.containerName, blobPath: p }
+  }
+
+  async get(p: string): Promise<{ body: Buffer; contentType?: string }> {
+    const container = await this.getContainer()
+    const block = container.getBlockBlobClient(p)
+    const resp = await block.download()
+    const chunks: Buffer[] = []
+    const reader = resp.readableStreamBody
+    if (!reader) throw new Error('No body stream')
+    for await (const chunk of reader) chunks.push(Buffer.from(chunk))
+    const body = Buffer.concat(chunks)
+    const contentType = resp.contentType
+    return { body, contentType: contentType || undefined }
+  }
+
+  async exists(p: string): Promise<boolean> {
+    const container = await this.getContainer()
+    const block = container.getBlockBlobClient(p)
+    return await block.exists()
+  }
+
+  async url(p: string): Promise<string | null> {
+    // Return a path the API can rewrite or a direct URL; for now return null to prefer proxying
+    return null
+  }
+}
+

--- a/services/ingestion-service/src/storage/local.ts
+++ b/services/ingestion-service/src/storage/local.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { StorageProvider, BlobPointer } from './provider'
+
+export class LocalFsProvider implements StorageProvider {
+  constructor(private rootDir: string, private container = 'local') {}
+
+  private abs(p: string) {
+    return path.isAbsolute(p) ? p : path.join(this.rootDir, p)
+  }
+
+  async put(p: string, content: Buffer | string, _contentType?: string): Promise<BlobPointer> {
+    const file = this.abs(p)
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, content)
+    return { container: this.container, blobPath: p }
+  }
+
+  async get(p: string): Promise<{ body: Buffer; contentType?: string }> {
+    const file = this.abs(p)
+    const body = await fs.readFile(file)
+    return { body }
+  }
+
+  async exists(p: string): Promise<boolean> {
+    const file = this.abs(p)
+    try {
+      await fs.access(file)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async url(p: string): Promise<string | null> {
+    // For local, we don't expose direct URLs; the API will proxy
+    return null
+  }
+}
+

--- a/services/ingestion-service/src/storage/provider.ts
+++ b/services/ingestion-service/src/storage/provider.ts
@@ -1,0 +1,12 @@
+export type BlobPointer = {
+  container: string
+  blobPath: string
+}
+
+export interface StorageProvider {
+  put(path: string, content: Buffer | string, contentType?: string): Promise<BlobPointer>
+  get(path: string): Promise<{ body: Buffer; contentType?: string }>
+  exists(path: string): Promise<boolean>
+  url(path: string): Promise<string | null>
+}
+


### PR DESCRIPTION
Implements T043 storage provider for ingestion-service.

- StorageProvider interface
- LocalFsProvider (default in dev)
- AzureBlobProvider (used when INGEST_STORAGE_PROVIDER=azure)
- Result endpoint returns gateway URLs for markdown/structure, which are served by the service
- Added @azure/storage-blob and env examples in infra/.env.example

Dev (Azurite):
- Ensure azurite is running (docker-compose already has it)
- Set in your env: INGEST_STORAGE_PROVIDER=azure, AZURE_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true, AZURE_STORAGE_CONTAINER=talvra

Prod (Azure):
- Set INGEST_STORAGE_PROVIDER=azure and AZURE_STORAGE_CONNECTION_STRING to your real Azure Storage connection string; set AZURE_STORAGE_CONTAINER

Test:
1) docker compose -f infra/docker-compose.yml up -d --build redis azurite ingestion-service api-gateway web
2) docker cp /path/to/test.pdf talvra_ingestion_service:/tmp/test.pdf
3) curl -sS -X POST http://localhost:3001/api/ingestion/start -H 'content-type: application/json' -d '{file:/tmp/test.pdf,doc_id:test}'
4) Visit http://localhost:5173/documents/test

Notes:
- We currently proxy blobs through the service; can add SAS URLs later if desired.