### PR TITLE
feat(canvas): T081 deep sync + ingestion bridge

### DIFF
--- a/services/canvas-service/src/index.ts
+++ b/services/canvas-service/src/index.ts
@@ -3,6 +3,7 @@ import { Pool } from 'pg'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import cookie from '@fastify/cookie'
+import { createHash } from 'node:crypto'
 
 const app = Fastify({ logger: true })
 
@@ -11,6 +12,7 @@ const CANVAS_HOST = process.env.CANVAS_SERVICE_HOST ?? '0.0.0.0'
 const CANVAS_PORT = Number(process.env.CANVAS_SERVICE_PORT ?? 4002)
 // Always default to docker network host 'postgres' inside container
 const DATABASE_URL = process.env.CANVAS_DATABASE_URL || 'postgresql://talvra:talvra@postgres:5432/talvra'
+const INGESTION_BASE = process.env.INGESTION_SERVICE_URL || 'http://ingestion-service:4010'
 
 const pool = new Pool({ connectionString: DATABASE_URL })
 
@@ -31,6 +33,20 @@ async function bootstrapDb() {
     ALTER TABLE courses ADD COLUMN IF NOT EXISTS term text;
     ALTER TABLE courses ADD COLUMN IF NOT EXISTS created_at timestamptz;
     ALTER TABLE courses ALTER COLUMN created_at SET DEFAULT now();
+
+    -- Documents synced from Canvas attachments/module items (minimal schema for dedupe and linkage)
+    CREATE TABLE IF NOT EXISTS canvas_documents (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      course_canvas_id text,
+      assignment_canvas_id text,
+      module_canvas_id text,
+      module_item_canvas_id text,
+      attachment_canvas_id text,
+      title text,
+      content_hash text UNIQUE,
+      doc_id text UNIQUE,
+      created_at timestamptz DEFAULT now()
+    );
   `)
 }
 
@@ -38,36 +54,36 @@ await app.register(cookie as any)
 
 app.get('/canvas/health', async () => ({ ok: true }))
 
-app.get('/canvas/courses', async (req, reply) => {
-  // If a logged-in user has a Canvas token, fetch from Canvas API
+async function getUserCanvasCreds(req: any): Promise<{ token: string; baseUrl: string } | null> {
   const SESSION_COOKIE = process.env.AUTH_SESSION_COOKIE ?? 'talvra.sid'
   const sid = (req.cookies as any)?.[SESSION_COOKIE]
-  const CANVAS_BASE_URL = process.env.CANVAS_BASE_URL || (await (async () => {
-    return '' as string
-  })())
+  const CANVAS_BASE_URL = process.env.CANVAS_BASE_URL || ''
+  if (!sid) return null
+  const sidRow = await pool.query('SELECT user_id FROM sessions WHERE id = $1', [sid])
+  if (!sidRow.rowCount || sidRow.rows.length === 0) return null
+  const userId = (sidRow.rows[0] as any).user_id as string
+  const tokRow = await pool.query(
+    'SELECT pgp_sym_decrypt(canvas_token_enc, $1) AS token, COALESCE(canvas_base_url, $2) AS base_url FROM users WHERE id = $3',
+    [process.env.CANVAS_TOKEN_SECRET ?? 'dev-canvas-secret', CANVAS_BASE_URL || null, userId]
+  )
+  const token = (tokRow.rows?.[0] as any)?.token as string | null
+  const baseUrl = ((tokRow.rows?.[0] as any)?.base_url as string | null) ?? CANVAS_BASE_URL
+  if (token && baseUrl) return { token, baseUrl }
+  return null
+}
 
-  if (sid) {
-    const sidRow = await pool.query('SELECT user_id FROM sessions WHERE id = $1', [sid])
-    if (sidRow.rowCount && sidRow.rows.length > 0) {
-      const userId = (sidRow.rows[0] as any).user_id as string
-      const tokRow = await pool.query(
-        "SELECT pgp_sym_decrypt(canvas_token_enc, $1) AS token, COALESCE(canvas_base_url, $2) AS base_url FROM users WHERE id = $3",
-        [process.env.CANVAS_TOKEN_SECRET ?? 'dev-canvas-secret', process.env.CANVAS_BASE_URL ?? null, userId]
-      )
-      const token = (tokRow.rows?.[0] as any)?.token as string | null
-      const baseUrl = ((tokRow.rows?.[0] as any)?.base_url as string | null) ?? process.env.CANVAS_BASE_URL ?? ''
-      if (token && baseUrl) {
-        const res = await fetch(`${baseUrl.replace(/\/$/, '')}/api/v1/courses?per_page=50`, {
-          headers: { authorization: `Bearer ${token}` }
-        })
-        if (res.ok) {
-          const data = (await res.json()) as Array<{ id: number; name: string }>
-          const courses = data.map((c) => ({ id: String(c.id), name: c.name, term: null as string | null }))
-          return { ok: true, courses }
-        } else if (res.status === 401 || res.status === 403) {
-          return reply.code(401).send({ error: { code: 'UNAUTHENTICATED', message: 'invalid Canvas token' } })
-        }
-      }
+app.get('/canvas/courses', async (req, reply) => {
+  const creds = await getUserCanvasCreds(req)
+  if (creds) {
+    const res = await fetch(`${creds.baseUrl.replace(/\/$/, '')}/api/v1/courses?per_page=50`, {
+      headers: { authorization: `Bearer ${creds.token}` }
+    })
+    if (res.ok) {
+      const data = (await res.json()) as Array<{ id: number; name: string }>
+      const courses = data.map((c) => ({ id: String(c.id), name: c.name, term: null as string | null }))
+      return { ok: true, courses }
+    } else if (res.status === 401 || res.status === 403) {
+      return reply.code(401).send({ error: { code: 'UNAUTHENTICATED', message: 'invalid Canvas token' } })
     }
   }
 
@@ -83,6 +99,107 @@ app.get('/canvas/courses', async (req, reply) => {
   }
   const { rows } = await pool.query('SELECT COALESCE(canvas_id, id::text) AS id, name, term FROM courses ORDER BY name ASC')
   return { ok: true, courses: rows }
+})
+
+app.post('/canvas/sync', async (req, reply) => {
+  const creds = await getUserCanvasCreds(req)
+  if (!creds) return reply.code(400).send({ error: { code: 'UNAUTHENTICATED', message: 'Canvas token/base URL not configured' } })
+
+  // Fetch courses to sync
+  const coursesRes = await fetch(`${creds.baseUrl.replace(/\/$/, '')}/api/v1/courses?per_page=50`, {
+    headers: { authorization: `Bearer ${creds.token}` }
+  })
+  if (!coursesRes.ok) return reply.code(coursesRes.status).send({ error: { code: 'CANVAS_ERROR', message: 'failed to list courses' } })
+  const courses = (await coursesRes.json()) as Array<{ id: number; name: string }>
+
+  const results: Array<{ course_id: string; processed: number; skipped: number }> = []
+
+  for (const course of courses) {
+    const courseId = String(course.id)
+    let processed = 0
+    let skipped = 0
+
+    // List modules with items (best-effort; ignores pagination for now)
+    const modsRes = await fetch(`${creds.baseUrl.replace(/\/$/, '')}/api/v1/courses/${courseId}/modules?per_page=50&include%5B%5D=items`, {
+      headers: { authorization: `Bearer ${creds.token}` }
+    })
+    if (!modsRes.ok) {
+      app.log.warn({ status: modsRes.status }, 'failed to list modules')
+      results.push({ course_id: courseId, processed, skipped })
+      continue
+    }
+    const modules = (await modsRes.json()) as Array<any>
+
+    for (const mod of modules) {
+      const moduleCanvasId = String(mod.id)
+      const items = Array.isArray(mod.items) ? mod.items as Array<any> : []
+      for (const item of items) {
+        try {
+          if (item?.type !== 'File') { skipped++; continue }
+          const moduleItemCanvasId = String(item.id)
+          const fileId = String(item.content_id ?? '')
+
+          // Fetch file metadata to get a download URL
+          let fileMeta: any = null
+          const fileRes = await fetch(`${creds.baseUrl.replace(/\/$/, '')}/api/v1/courses/${courseId}/files/${fileId}`, {
+            headers: { authorization: `Bearer ${creds.token}` }
+          })
+          if (fileRes.ok) {
+            fileMeta = await fileRes.json()
+          } else {
+            // Fallback: try global files endpoint
+            const alt = await fetch(`${creds.baseUrl.replace(/\/$/, '')}/api/v1/files/${fileId}`, { headers: { authorization: `Bearer ${creds.token}` } })
+            if (alt.ok) fileMeta = await alt.json()
+          }
+          if (!fileMeta) { skipped++; continue }
+
+          const downloadUrl: string | undefined = fileMeta?.url || fileMeta?.download_url
+          const filename: string = fileMeta?.filename || fileMeta?.display_name || item?.title || `file-${fileId}`
+          if (!downloadUrl) { skipped++; continue }
+
+          // Download file to compute content hash (best-effort; assume presigned URL may not need token)
+          const fileResp = await fetch(downloadUrl, { headers: { authorization: `Bearer ${creds.token}` } })
+          if (!fileResp.ok) { skipped++; continue }
+          const buf = Buffer.from(await fileResp.arrayBuffer())
+          const hash = createHash('sha256').update(buf).digest('hex')
+
+          // Dedupe by content hash
+          const existing = await pool.query('SELECT id, doc_id FROM canvas_documents WHERE content_hash = $1', [hash])
+          if (existing.rowCount && existing.rows.length > 0) { skipped++; continue }
+
+          // Create record and trigger ingestion
+          const docId = `canvas-${courseId}-${moduleItemCanvasId}-${hash.slice(0, 8)}`
+          await pool.query(
+            'INSERT INTO canvas_documents (course_canvas_id, module_canvas_id, module_item_canvas_id, attachment_canvas_id, title, content_hash, doc_id) VALUES ($1,$2,$3,$4,$5,$6,$7) ON CONFLICT (content_hash) DO NOTHING',
+            [courseId, moduleCanvasId, moduleItemCanvasId, fileId, filename, hash, docId]
+          )
+
+          const ingestRes = await fetch(`${INGESTION_BASE.replace(/\/$/, '')}/ingestion/start`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              url: downloadUrl,
+              filename,
+              doc_id: docId,
+              context: { course_id: courseId, module_id: moduleCanvasId, module_item_id: moduleItemCanvasId }
+            })
+          })
+          if (!ingestRes.ok) {
+            app.log.warn({ status: ingestRes.status }, 'ingestion start failed')
+          } else {
+            processed++
+          }
+        } catch (err) {
+          app.log.warn({ err }, 'item processing failed')
+          skipped++
+        }
+      }
+    }
+
+    results.push({ course_id: courseId, processed, skipped })
+  }
+
+  return { ok: true, results }
 })
 
 app.addHook('onClose', async () => {


### PR DESCRIPTION
- Add /canvas/sync to enumerate modules/items/files for the user’s courses
- Dedupe by sha256 content hash and persist minimal canvas_documents linkage
- Trigger ingestion via POST /ingestion/start using URL + filename and include course/module context
- Ingestion service now accepts url+filename and optional context, enqueues event with context