### PR TITLE
feat(ai,canvas): idempotent embeddings and auto-trigger after Canvas sync (Phases 1-2)

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -685,7 +685,7 @@
           "paths": ["services/canvas-service/**", "services/ai-service/**", "services/api-gateway/**"],
           "steps": [
             "Phase 1 (DONE): After successful ingestion of a Canvas document, trigger /ai/embed for the resulting doc_id",
-            "Phase 2 (NEXT): Ensure idempotency and retries (skip if embeddings already exist)",
+            "Phase 2 (DONE): Ensure idempotency and retries (skip if embeddings already exist)",
             "Propagate request id and handle failures with logging",
             "Optionally batch embed to avoid rate limits"
           ],


### PR DESCRIPTION
This PR supersedes #52 by starting from main on a fresh branch, and includes:

- AI service: make POST /ai/embed idempotent; add optional force flag
- Canvas service: trigger /ai/embed after ingestion with simple retry + request-id propagation
- Tasks: update T082 to mark Phase 1 + Phase 2 done

Why
- Avoid redundant embedding work and reduce load
- Ensure semantic search is available automatically after sync

Testing
- Two consecutive /api/ai/embed calls for the same doc_id: second returns skipped: exists
- Canvas sync (with valid session/token) triggers auto-embedding; search works without manual embedding

Next
- Optional Phase 3: batching embed triggers to reduce rate limits
