### PR TITLE
feat(web+canvas): Course Detail UI (documents+assignments) and assignments endpoint

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -587,6 +587,48 @@
           "completed": true
         },
         {
+          "id": "T074",
+          "title": "Canvas assignments endpoint and per-course documents filter",
+          "branch": "backend/canvas-assignments-endpoint",
+          "paths": ["services/canvas-service/**"],
+          "steps": [
+            "Extend GET /canvas/documents to accept course_id filter",
+            "Add GET /canvas/assignments?course_id to fetch assignments via Canvas API"
+          ],
+          "run": ["curl /api/canvas/assignments?course_id=123"],
+          "acceptance": [
+            "/canvas/documents returns only documents for the course when filtered",
+            "/canvas/assignments returns id,name,due_at,html_url for assignments"
+          ],
+          "pr": {
+            "title": "feat(canvas): assignments endpoint + per-course documents filter",
+            "body": "What: backend endpoints to support course detail UI."
+          },
+          "completed": true
+        },
+        {
+          "id": "T075",
+          "title": "Frontend course detail: documents and assignments",
+          "branch": "web/course-docs-assignments",
+          "paths": ["frontend/web/src/Areas/Courses/**", "frontend/web/src/app/AppRoutes.tsx"],
+          "steps": [
+            "Add /courses/:courseId route",
+            "Show documents for course using /api/canvas/documents?course_id",
+            "Show assignments for course using /api/canvas/assignments?course_id",
+            "Link Courses list to course detail"
+          ],
+          "run": ["pnpm -C frontend --filter web dev"],
+          "acceptance": [
+            "Navigating to a course shows documents and assignments",
+            "Document actions navigate to document detail/AI/Video"
+          ],
+          "pr": {
+            "title": "feat(web): course detail with documents and assignments",
+            "body": "What: new UI page; How: calls Canvas endpoints; Actions: links to doc pages."
+          },
+          "completed": false
+        },
+        {
           "id": "T071",
           "title": "Notification service and reminders",
           "branch": "backend/notify-reminders",

--- a/frontend/web/src/Areas/Courses/Detail.tsx
+++ b/frontend/web/src/Areas/Courses/Detail.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink, TalvraButton } from '@ui';
+import { FRONT_ROUTES, buildPath } from '@/app/routes';
+
+const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
+
+async function fetchJSON<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return (await res.json()) as T;
+}
+
+interface DocRow {
+  doc_id: string;
+  title: string | null;
+  course_canvas_id: string | null;
+  module_canvas_id: string | null;
+  module_item_canvas_id: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  created_at: string;
+}
+
+interface AssignmentRow {
+  id: string;
+  name: string;
+  due_at?: string | null;
+  html_url?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export default function CourseDetailArea() {
+  const { courseId } = useParams<{ courseId: string }>();
+  const [docs, setDocs] = useState<DocRow[] | null>(null);
+  const [assignments, setAssignments] = useState<AssignmentRow[] | null>(null);
+  const [errorDocs, setErrorDocs] = useState<string | null>(null);
+  const [errorAssign, setErrorAssign] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadDocs() {
+      setErrorDocs(null);
+      try {
+        const data = await fetchJSON<{ ok: true; documents: DocRow[] }>(
+          `${API_BASE}/api/canvas/documents?course_id=${encodeURIComponent(courseId || '')}&limit=200`
+        );
+        if (!cancelled) setDocs(data.documents);
+      } catch (e: any) {
+        if (!cancelled) setErrorDocs(String(e?.message || e));
+      }
+    }
+    async function loadAssignments() {
+      setErrorAssign(null);
+      try {
+        const data = await fetchJSON<{ ok: true; assignments: AssignmentRow[] }>(
+          `${API_BASE}/api/canvas/assignments?course_id=${encodeURIComponent(courseId || '')}`
+        );
+        if (!cancelled) setAssignments(data.assignments);
+      } catch (e: any) {
+        if (!cancelled) setErrorAssign(String(e?.message || e));
+      }
+    }
+    if (courseId) {
+      void loadDocs();
+      void loadAssignments();
+    }
+    return () => { cancelled = true };
+  }, [courseId]);
+
+  return (
+    <TalvraSurface>
+      <TalvraStack>
+        <TalvraText as="h1">Course {courseId}</TalvraText>
+
+        <TalvraStack>
+          <TalvraText as="h2">Documents</TalvraText>
+          {errorDocs && <TalvraText>Error loading documents: {errorDocs}</TalvraText>}
+          <TalvraCard>
+            <TalvraStack>
+              {!docs ? (
+                <TalvraText>Loading…</TalvraText>
+              ) : docs.length === 0 ? (
+                <TalvraText>No documents synced yet. Try Settings → Sync now.</TalvraText>
+              ) : (
+                docs.map((d) => (
+                  <TalvraCard key={d.doc_id}>
+                    <TalvraStack>
+                      <TalvraText as="h4">{d.title ?? d.doc_id}</TalvraText>
+                      <TalvraStack>
+                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_DETAIL, { documentId: d.doc_id })}>Open</TalvraLink>
+                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_AI, { documentId: d.doc_id })}>AI</TalvraLink>
+                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_VIDEO, { documentId: d.doc_id })}>Video</TalvraLink>
+                      </TalvraStack>
+                      <TalvraText style={{ color: '#64748b' }}>
+                        {d.mime_type ?? 'unknown'} • {d.size_bytes ? `${d.size_bytes} bytes` : 'size unknown'} • {new Date(d.created_at).toLocaleString()}
+                      </TalvraText>
+                    </TalvraStack>
+                  </TalvraCard>
+                ))
+              )}
+            </TalvraStack>
+          </TalvraCard>
+        </TalvraStack>
+
+        <TalvraStack>
+          <TalvraText as="h2">Assignments</TalvraText>
+          {errorAssign && <TalvraText>Error loading assignments: {errorAssign}</TalvraText>}
+          <TalvraCard>
+            <TalvraStack>
+              {!assignments ? (
+                <TalvraText>Loading…</TalvraText>
+              ) : assignments.length === 0 ? (
+                <TalvraText>No assignments found.</TalvraText>
+              ) : (
+                assignments.map((a) => (
+                  <TalvraCard key={a.id}>
+                    <TalvraStack>
+                      <TalvraText as="h4">{a.name}</TalvraText>
+                      <TalvraText style={{ color: '#64748b' }}>
+                        {a.due_at ? `Due ${new Date(a.due_at).toLocaleString()}` : 'No due date'}
+                      </TalvraText>
+                      <TalvraStack>
+                        {a.html_url && (
+                          <a href={a.html_url} target="_blank" rel="noreferrer">Open in Canvas</a>
+                        )}
+                      </TalvraStack>
+                    </TalvraStack>
+                  </TalvraCard>
+                ))
+              )}
+            </TalvraStack>
+          </TalvraCard>
+        </TalvraStack>
+
+        <TalvraStack>
+          <TalvraText as="h2">Navigation</TalvraText>
+          <TalvraStack>
+            <TalvraLink href={buildPath(FRONT_ROUTES.COURSES)}>
+              Back to Courses
+            </TalvraLink>
+            <TalvraLink href={buildPath(FRONT_ROUTES.SETTINGS)}>
+              Settings
+            </TalvraLink>
+          </TalvraStack>
+        </TalvraStack>
+      </TalvraStack>
+    </TalvraSurface>
+  );
+}

--- a/frontend/web/src/Areas/Courses/index.tsx
+++ b/frontend/web/src/Areas/Courses/index.tsx
@@ -65,6 +65,9 @@ export default function CoursesArea() {
                         <TalvraText as="h4">{c.name}</TalvraText>
                         <TalvraText>ID: {c.id}</TalvraText>
                         {c.term && <TalvraText>Term: {c.term}</TalvraText>}
+                        <TalvraLink href={buildPath(FRONT_ROUTES.COURSE_DETAIL, { courseId: c.id })}>
+                          View course
+                        </TalvraLink>
                       </TalvraStack>
                     </TalvraCard>
                   ))

--- a/frontend/web/src/app/AppRoutes.tsx
+++ b/frontend/web/src/app/AppRoutes.tsx
@@ -8,6 +8,7 @@ import DocumentsArea from '@/Areas/Documents';
 import DocumentDetailArea from '@/Areas/Documents/Detail';
 import DocumentAIArea from '@/Areas/Documents/AI';
 import DocumentVideoArea from '@/Areas/Documents/Video';
+import CourseDetailArea from '@/Areas/Courses/Detail';
 
 // Create router configuration
 const router = createBrowserRouter([
@@ -32,6 +33,14 @@ const router = createBrowserRouter([
     element: (
       <Suspense fallback={<div>Loading...</div>}>
         <CoursesArea />
+      </Suspense>
+    ),
+  },
+  {
+    path: buildPath(FRONT_ROUTES.COURSE_DETAIL, { courseId: ':courseId' }),
+    element: (
+      <Suspense fallback={<div>Loading...</div>}>
+        <CourseDetailArea />
       </Suspense>
     ),
   },


### PR DESCRIPTION
This PR adds course-centric UX and supporting backend endpoints:

Backend (canvas-service)
- GET /canvas/documents now supports ?course_id= to filter documents by course
- NEW GET /canvas/assignments?course_id=ID calls Canvas API and returns id,name,due_at,html_url

Frontend (web)
- New /courses/:courseId page that shows:
  - Documents for the course with actions (Open, AI, Video)
  - Assignments for the course with Open-in-Canvas link
- Courses list now links to course detail

Docs
- tasks.json updated with T074 and T075

Why
- Users can navigate from Courses to see their actual synced class documents and live assignments, then take actions.

Notes
- Assignments require a saved Canvas token in Settings
- Documents require running a sync (Settings → Sync now)

Acceptance
- Visit /courses to list courses, click a course to see documents and assignments
- /api/canvas/documents?course_id=... filters server-side
- /api/canvas/assignments?course_id=... returns assignments from Canvas
