### PR TITLE
feat(canvas+web): per-course sync endpoint and Course Detail wiring

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -626,7 +626,27 @@
             "title": "feat(web): course detail with documents and assignments",
             "body": "What: new UI page; How: calls Canvas endpoints; Actions: links to doc pages."
           },
-          "completed": false
+          "completed": true
+        },
+        {
+          "id": "T076",
+          "title": "Per-course sync endpoint and UI wiring",
+          "branch": "backend/canvas-sync-course",
+          "paths": ["services/canvas-service/**", "frontend/web/src/Areas/Courses/Detail.tsx"],
+          "steps": [
+            "Add POST /canvas/sync/course/:course_id to sync a single course",
+            "Update Course Detail 'Sync now' button to call per-course endpoint and refresh lists"
+          ],
+          "run": ["curl -X POST /api/canvas/sync/course/123"],
+          "acceptance": [
+            "Per-course sync succeeds and new docs appear for that course only",
+            "Course Detail 'Sync now' refreshes documents and assignments"
+          ],
+          "pr": {
+            "title": "feat(canvas+web): per-course sync endpoint and Course Detail wiring",
+            "body": "What: backend per-course sync + front wiring; Why: tighter UX control."
+          },
+          "completed": true
         },
         {
           "id": "T071",

--- a/frontend/web/src/Areas/Courses/Detail.tsx
+++ b/frontend/web/src/Areas/Courses/Detail.tsx
@@ -11,6 +11,17 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function postJSON<T>(url: string, body?: any): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return (await res.json()) as T;
+}
+
 interface DocRow {
   doc_id: string;
   title: string | null;
@@ -37,36 +48,57 @@ export default function CourseDetailArea() {
   const [assignments, setAssignments] = useState<AssignmentRow[] | null>(null);
   const [errorDocs, setErrorDocs] = useState<string | null>(null);
   const [errorAssign, setErrorAssign] = useState<string | null>(null);
+  const [syncBusy, setSyncBusy] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+
+  async function loadDocs(cancelledFlag?: { v: boolean }) {
+    setErrorDocs(null);
+    try {
+      const data = await fetchJSON<{ ok: true; documents: DocRow[] }>(
+        `${API_BASE}/api/canvas/documents?course_id=${encodeURIComponent(courseId || '')}&limit=200`
+      );
+      if (!cancelledFlag?.v) setDocs(data.documents);
+    } catch (e: any) {
+      if (!cancelledFlag?.v) setErrorDocs(String(e?.message || e));
+    }
+  }
+
+  async function loadAssignments(cancelledFlag?: { v: boolean }) {
+    setErrorAssign(null);
+    try {
+      const data = await fetchJSON<{ ok: true; assignments: AssignmentRow[] }>(
+        `${API_BASE}/api/canvas/assignments?course_id=${encodeURIComponent(courseId || '')}`
+      );
+      if (!cancelledFlag?.v) setAssignments(data.assignments);
+    } catch (e: any) {
+      if (!cancelledFlag?.v) setErrorAssign(String(e?.message || e));
+    }
+  }
+
+  async function syncNow() {
+    setSyncBusy(true);
+    setSyncMsg(null);
+    try {
+      const res = await postJSON<{ ok: true; result: { course_id: string; processed: number; skipped: number } }>(
+        `${API_BASE}/api/canvas/sync/course/${encodeURIComponent(courseId || '')}`,
+        {}
+      );
+      setSyncMsg(`Sync done: processed ${res.result.processed}, skipped ${res.result.skipped} for course ${res.result.course_id}.`);
+      await Promise.all([loadDocs(), loadAssignments()]);
+    } catch (e: any) {
+      setSyncMsg(`Sync failed: ${String(e?.message || e)}`);
+    } finally {
+      setSyncBusy(false);
+    }
+  }
 
   useEffect(() => {
-    let cancelled = false;
-    async function loadDocs() {
-      setErrorDocs(null);
-      try {
-        const data = await fetchJSON<{ ok: true; documents: DocRow[] }>(
-          `${API_BASE}/api/canvas/documents?course_id=${encodeURIComponent(courseId || '')}&limit=200`
-        );
-        if (!cancelled) setDocs(data.documents);
-      } catch (e: any) {
-        if (!cancelled) setErrorDocs(String(e?.message || e));
-      }
-    }
-    async function loadAssignments() {
-      setErrorAssign(null);
-      try {
-        const data = await fetchJSON<{ ok: true; assignments: AssignmentRow[] }>(
-          `${API_BASE}/api/canvas/assignments?course_id=${encodeURIComponent(courseId || '')}`
-        );
-        if (!cancelled) setAssignments(data.assignments);
-      } catch (e: any) {
-        if (!cancelled) setErrorAssign(String(e?.message || e));
-      }
-    }
+    let cancelled = { v: false };
     if (courseId) {
-      void loadDocs();
-      void loadAssignments();
+      void loadDocs(cancelled);
+      void loadAssignments(cancelled);
     }
-    return () => { cancelled = true };
+    return () => { cancelled.v = true };
   }, [courseId]);
 
   return (
@@ -76,6 +108,12 @@ export default function CourseDetailArea() {
 
         <TalvraStack>
           <TalvraText as="h2">Documents</TalvraText>
+          <TalvraStack>
+            <TalvraButton disabled={syncBusy} onClick={syncNow}>
+              {syncBusy ? 'Syncing…' : 'Sync now'}
+            </TalvraButton>
+            {syncMsg && <TalvraText>{syncMsg}</TalvraText>}
+          </TalvraStack>
           {errorDocs && <TalvraText>Error loading documents: {errorDocs}</TalvraText>}
           <TalvraCard>
             <TalvraStack>


### PR DESCRIPTION
Backend
- POST /canvas/sync/course/:course_id to sync a single course (modules/items/files -> ingestion)
- Uses same dedupe and metadata capture as global sync

Frontend
- Course Detail 'Sync now' now calls per-course endpoint
- After success, refreshes documents and assignments and shows a summary

Docs
- tasks.json: add T076 (per-course sync) and mark T075 done

Why
- Avoid syncing all courses when a user wants to refresh one course

Acceptance
- POST /api/canvas/sync/course/{courseId} returns processed/skipped for that course
- Course Detail 'Sync now' refreshes content for that course only
