### PR TITLE
feat(web): Document Detail embeddings + semantic search

### DIFF
--- a/docs/tasks.json
+++ b/docs/tasks.json
@@ -682,6 +682,32 @@
       ]
     },
     {
+      "name": "Phase 7.5 - Document UX enhancements",
+      "tasks": [
+        {
+          "id": "T077",
+          "title": "Document Detail: Embed + Semantic Search UI",
+          "branch": "web/doc-embed-search",
+          "paths": ["frontend/web/src/Areas/Documents/Detail.tsx"],
+          "steps": [
+            "Add button to call POST /api/ai/embed for current document",
+            "Add per-doc search input calling GET /api/ai/search?doc_id=...&q=...&k=...",
+            "Render results with score and snippet"
+          ],
+          "run": ["Open /documents/:documentId, click Compute embeddings, then search"],
+          "acceptance": [
+            "Embeddings compute succeeds or returns skipped if already present",
+            "Search returns top-k snippets for the doc and displays them"
+          ],
+          "pr": {
+            "title": "feat(web): Document Detail embeds + semantic search UI",
+            "body": "What: embed and search controls on Document Detail; How: calls ai-service endpoints via gateway."
+          },
+          "completed": false
+        }
+      ]
+    },
+    {
       "name": "Phase 8 - Canvas real OAuth and ingestion bridge",
       "tasks": [
         {

--- a/frontend/web/src/Areas/Documents/Detail.tsx
+++ b/frontend/web/src/Areas/Documents/Detail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraCard, TalvraLink, TalvraButton } from '@ui';
 import { useParams } from 'react-router-dom';
 
 const API_BASE: string = (import.meta as any).env?.VITE_API_BASE ?? 'http://localhost:3001';
@@ -16,11 +16,38 @@ async function fetchJSON<T>(url: string): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function postJSON<T>(url: string, body?: any): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`));
+  return (await res.json()) as T;
+}
+
+interface SearchResult {
+  id: string;
+  doc_id: string;
+  score: number;
+  snippet: string;
+}
+
 export default function DocumentDetailArea() {
   const { documentId } = useParams<{ documentId: string }>();
   const [markdown, setMarkdown] = useState<string | null>(null);
   const [structure, setStructure] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Embed/search UI state
+  const [embedBusy, setEmbedBusy] = useState(false);
+  const [embedMsg, setEmbedMsg] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [k, setK] = useState(5);
+  const [searchBusy, setSearchBusy] = useState(false);
+  const [searchErr, setSearchErr] = useState<string | null>(null);
+  const [results, setResults] = useState<SearchResult[] | null>(null);
 
   const resultUrl = useMemo(() => `${API_BASE}/api/ingestion/result/${encodeURIComponent(documentId || '')}`, [documentId]);
 
@@ -50,11 +77,104 @@ export default function DocumentDetailArea() {
     };
   }, [documentId, resultUrl]);
 
+  async function onEmbed() {
+    if (!documentId) return;
+    setEmbedBusy(true);
+    setEmbedMsg(null);
+    try {
+      const res = await postJSON<{ ok: true; doc_id: string; count?: number; skipped?: string }>(
+        `${API_BASE}/api/ai/embed`,
+        { doc_id: documentId }
+      );
+      if ((res as any).skipped === 'exists') {
+        setEmbedMsg('Embeddings already exist.');
+      } else {
+        setEmbedMsg(`Computed embeddings for ${res.count ?? 0} chunk(s).`);
+      }
+    } catch (e: any) {
+      setEmbedMsg(`Embed failed: ${String(e?.message || e)}`);
+    } finally {
+      setEmbedBusy(false);
+    }
+  }
+
+  async function onSearch() {
+    if (!documentId || !query.trim()) return;
+    setSearchBusy(true);
+    setSearchErr(null);
+    setResults(null);
+    try {
+      const url = `${API_BASE}/api/ai/search?doc_id=${encodeURIComponent(documentId)}&q=${encodeURIComponent(query.trim())}&k=${encodeURIComponent(String(k))}`;
+      const res = await fetchJSON<{ ok: true; q: string; results: SearchResult[] }>(url);
+      setResults(res.results || []);
+    } catch (e: any) {
+      setSearchErr(String(e?.message || e));
+    } finally {
+      setSearchBusy(false);
+    }
+  }
+
   return (
     <TalvraSurface>
       <TalvraStack>
         <TalvraText as="h1">Document: {documentId}</TalvraText>
         {error && <TalvraText>Error: {error}</TalvraText>}
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Embeddings</TalvraText>
+            <TalvraStack>
+              <TalvraButton disabled={embedBusy} onClick={onEmbed}>
+                {embedBusy ? 'Embedding…' : 'Compute embeddings'}
+              </TalvraButton>
+              {embedMsg && <TalvraText>{embedMsg}</TalvraText>}
+            </TalvraStack>
+          </TalvraStack>
+        </TalvraCard>
+
+        <TalvraCard>
+          <TalvraStack>
+            <TalvraText as="h3">Semantic search (within this document)</TalvraText>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                placeholder="Enter search keywords…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                style={{ padding: 8, border: '1px solid #ddd', borderRadius: 6, minWidth: 260 }}
+              />
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={k}
+                onChange={(e) => setK(Math.max(1, Math.min(Number(e.target.value) || 5, 20)))}
+                style={{ width: 80, padding: 8, border: '1px solid #ddd', borderRadius: 6 }}
+                title="Top-K"
+              />
+              <TalvraButton disabled={searchBusy || !query.trim()} onClick={onSearch}>
+                {searchBusy ? 'Searching…' : 'Search'}
+              </TalvraButton>
+            </div>
+            {searchErr && <TalvraText>Error: {searchErr}</TalvraText>}
+            {results && (
+              <TalvraStack>
+                {results.length === 0 ? (
+                  <TalvraText>No matches.</TalvraText>
+                ) : (
+                  results.map((r) => (
+                    <TalvraCard key={r.id}>
+                      <TalvraStack>
+                        <TalvraText style={{ color: '#64748b' }}>score {(r.score * 100).toFixed(1)}%</TalvraText>
+                        <TalvraText>{r.snippet}</TalvraText>
+                      </TalvraStack>
+                    </TalvraCard>
+                  ))
+                )}
+              </TalvraStack>
+            )}
+          </TalvraStack>
+        </TalvraCard>
 
         <TalvraCard>
           <TalvraStack>


### PR DESCRIPTION
Adds two capabilities to the Document Detail page:\n\n- Embeddings: button to compute embeddings (POST /api/ai/embed). Shows 'skipped' when embeddings already exist.\n- Semantic search (per-document): input + top-k selector calling GET /api/ai/search with snippets and scores.\n\nWhy\n- Let users run per-doc retrieval primitives without leaving the document screen.\n\nNotes\n- Uses gateway endpoints (/api/ai/*). Embeddings rely on ingested markdown being present first.\n- For dev without OPENAI_API_KEY, deterministic fallback embeddings are used.\n\nAcceptance\n- On /documents/:documentId, clicking 'Compute embeddings' succeeds or reports 'Embeddings already exist'.\n- Entering a query and pressing 'Search' shows top-k results with snippets.\n