### PR TITLE
feat(ui): Button variants + Grid layouts in Docs & Course Detail

### DIFF
--- a/frontend/packages/talvra-ui/src/TalvraButton.tsx
+++ b/frontend/packages/talvra-ui/src/TalvraButton.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, type ButtonHTMLAttributes } from 'react';
 
 export interface TalvraButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
 }
 
 export const TalvraButton = styled.button<TalvraButtonProps>`
@@ -12,15 +13,26 @@ export const TalvraButton = styled.button<TalvraButtonProps>`
   cursor: pointer;
   border: 1px solid transparent;
   border-radius: ${({ theme }) => theme.borderRadius.md};
-  background: ${({ theme }) => theme.colors.primary[600]};
-  color: ${({ theme }) => theme.colors.white};
   padding: 0.5rem 1rem;
   font: inherit;
   box-shadow: ${({ theme }) => theme.shadows.base};
   transition: ${({ theme }) => theme.transitions.all};
 
+  /* default (primary) */
+  background: ${({ theme, variant }) => variant === 'danger' ? theme.colors.danger[600]
+    : variant === 'secondary' ? theme.colors.white
+    : variant === 'ghost' ? 'transparent'
+    : theme.colors.primary[600]};
+  color: ${({ theme, variant }) => variant === 'secondary' ? theme.colors.gray[800]
+    : variant === 'ghost' ? theme.colors.primary[700]
+    : theme.colors.white};
+  border-color: ${({ theme, variant }) => variant === 'secondary' ? theme.colors.gray[300] : 'transparent'};
+
   &:hover {
-    background: ${({ theme }) => theme.colors.primary[700]};
+    background: ${({ theme, variant }) => variant === 'danger' ? theme.colors.danger[700]
+      : variant === 'secondary' ? theme.colors.gray[50]
+      : variant === 'ghost' ? theme.colors.primary[50]
+      : theme.colors.primary[700]};
     transform: translateY(-1px);
     box-shadow: ${({ theme }) => theme.shadows.md};
   }

--- a/frontend/web/src/Areas/Admin/index.tsx
+++ b/frontend/web/src/Areas/Admin/index.tsx
@@ -50,9 +50,9 @@ export default function AdminArea() {
           <SectionHeader title="Welcome back" subtitle="Quick actions to get you going." />
           <TalvraStack style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
             <TalvraButton onClick={syncAllNow}>Sync Canvas</TalvraButton>
-            <TalvraButton as="a" href={buildPath(FRONT_ROUTES.COURSES)}>Browse Courses</TalvraButton>
-            <TalvraButton as="a" href={buildPath(FRONT_ROUTES.DOCUMENTS)}>View Documents</TalvraButton>
-            <TalvraButton as="a" href={buildPath(FRONT_ROUTES.SETTINGS)}>Settings</TalvraButton>
+<TalvraButton as="a" href={buildPath(FRONT_ROUTES.COURSES)} variant="secondary">Browse Courses</TalvraButton>
+            <TalvraButton as="a" href={buildPath(FRONT_ROUTES.DOCUMENTS)} variant="secondary">View Documents</TalvraButton>
+            <TalvraButton as="a" href={buildPath(FRONT_ROUTES.SETTINGS)} variant="secondary">Settings</TalvraButton>
           </TalvraStack>
           {syncMsg && <TalvraText>{syncMsg}</TalvraText>}
         </TalvraStack>

--- a/frontend/web/src/Areas/Courses/Detail.tsx
+++ b/frontend/web/src/Areas/Courses/Detail.tsx
@@ -174,7 +174,7 @@ useEffect(() => {
   return (
     <TalvraSurface>
       <TalvraStack>
-<SectionHeader title={header} right={<TalvraButton onClick={rename}>Rename</TalvraButton>} />
+<SectionHeader title={header} right={<TalvraButton onClick={rename} variant="secondary">Rename</TalvraButton>} />
 
 <TalvraStack>
           <TalvraText as="h2">Documents</TalvraText>
@@ -198,28 +198,30 @@ useEffect(() => {
             </TalvraCard>
           )}
           {errorDocs && <TalvraText>Error loading documents: {errorDocs}</TalvraText>}
-          <TalvraCard>
+<TalvraCard>
             <TalvraStack>
               {!docs ? (
                 <TalvraText>Loading…</TalvraText>
               ) : docs.length === 0 ? (
                 <TalvraText>No documents synced yet. Try Settings → Sync now.</TalvraText>
               ) : (
-                docs.map((d) => (
-                  <TalvraCard key={d.doc_id}>
-                    <TalvraStack>
-                      <TalvraText as="h4">{d.title ?? d.doc_id}</TalvraText>
+                <Grid>
+                  {docs.map((d) => (
+                    <TalvraCard key={d.doc_id}>
                       <TalvraStack>
-                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_DETAIL, { documentId: d.doc_id })}>Open</TalvraLink>
-                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_AI, { documentId: d.doc_id })}>AI</TalvraLink>
-                        <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_VIDEO, { documentId: d.doc_id })}>Video</TalvraLink>
+                        <TalvraText as="h4">{d.title ?? d.doc_id}</TalvraText>
+                        <TalvraStack>
+                          <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_DETAIL, { documentId: d.doc_id })}>Open</TalvraLink>
+                          <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_AI, { documentId: d.doc_id })}>AI</TalvraLink>
+                          <TalvraLink href={buildPath(FRONT_ROUTES.DOCUMENT_VIDEO, { documentId: d.doc_id })}>Video</TalvraLink>
+                        </TalvraStack>
+                        <TalvraText style={{ color: '#64748b' }}>
+                          {d.mime_type ?? 'unknown'} • {d.size_bytes ? `${d.size_bytes} bytes` : 'size unknown'} • {new Date(d.created_at).toLocaleString()}
+                        </TalvraText>
                       </TalvraStack>
-                      <TalvraText style={{ color: '#64748b' }}>
-                        {d.mime_type ?? 'unknown'} • {d.size_bytes ? `${d.size_bytes} bytes` : 'size unknown'} • {new Date(d.created_at).toLocaleString()}
-                      </TalvraText>
-                    </TalvraStack>
-                  </TalvraCard>
-                ))
+                    </TalvraCard>
+                  ))}
+                </Grid>
               )}
             </TalvraStack>
           </TalvraCard>

--- a/frontend/web/src/Areas/Courses/index.tsx
+++ b/frontend/web/src/Areas/Courses/index.tsx
@@ -87,7 +87,7 @@ export default function CoursesArea() {
                           <TalvraLink href={buildPath(FRONT_ROUTES.COURSE_DETAIL, { courseId: c.id })}>
                             View course
                           </TalvraLink>
-                          <TalvraButton onClick={() => renameCourse(c)}>
+<TalvraButton onClick={() => renameCourse(c)} variant="secondary">
                             Rename
                           </TalvraButton>
                         </TalvraStack>

--- a/frontend/web/src/Areas/Documents/AI.tsx
+++ b/frontend/web/src/Areas/Documents/AI.tsx
@@ -129,21 +129,23 @@ export default function DocumentAI() {
                   </TalvraStack>
                 </TalvraCard>
                 <TalvraStack>
-                  <TalvraButton
+<TalvraButton
                     onClick={() => {
                       setCardIdx((i) => (i - 1 + cards.length) % cards.length);
                       setShowAnswer(false);
                       setShowHint(false);
                     }}
+                    variant="secondary"
                   >
                     Previous
                   </TalvraButton>
-                  <TalvraButton
+<TalvraButton
                     onClick={() => {
                       setCardIdx((i) => (i + 1) % cards.length);
                       setShowAnswer(false);
                       setShowHint(false);
                     }}
+                    variant="secondary"
                   >
                     Next
                   </TalvraButton>

--- a/frontend/web/src/Areas/Documents/index.tsx
+++ b/frontend/web/src/Areas/Documents/index.tsx
@@ -1,4 +1,4 @@
-import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, SectionHeader } from '@ui';
+import { TalvraSurface, TalvraStack, TalvraText, TalvraLink, TalvraCard, SectionHeader, Grid } from '@ui';
 import { FRONT_ROUTES, buildPath } from '@/app/routes';
 import { useEffect, useState } from 'react';
 
@@ -53,7 +53,7 @@ export default function DocumentsArea() {
             ) : docs.length === 0 ? (
               <TalvraText>No documents found yet. Try Settings → Sync now after saving your Canvas token.</TalvraText>
             ) : (
-              <TalvraStack>
+<Grid>
                 {docs.map((d) => (
                   <TalvraCard key={d.doc_id}>
                     <TalvraStack>
@@ -69,7 +69,7 @@ export default function DocumentsArea() {
                     </TalvraStack>
                   </TalvraCard>
                 ))}
-              </TalvraStack>
+              </Grid>
             )}
           </TalvraStack>
         </TalvraCard>

--- a/frontend/web/src/components/CanvasTokenSettings.tsx
+++ b/frontend/web/src/components/CanvasTokenSettings.tsx
@@ -129,7 +129,7 @@ placeholder="Enter Canvas access token"
             <TalvraButton disabled={busy || canvasToken.trim() === ''} onClick={saveCanvasToken}>
               Save token
             </TalvraButton>
-            <TalvraButton disabled={busy} onClick={clearCanvasToken}>
+<TalvraButton disabled={busy} onClick={clearCanvasToken} variant="secondary">
               Clear token
             </TalvraButton>
           </TalvraStack>


### PR DESCRIPTION
This follow-up PR continues the lovable UI port with more polish.

- Add variants to TalvraButton: primary (default), secondary, ghost, danger
- Apply secondary variant to less-prominent actions (nav, Rename, Prev/Next)
- Switch Documents index and Course Detail documents list to Grid for a denser layout
- Build passes via vite

Next polish candidates:
- Button ghost variant adoption for inline, low-emphasis actions
- Replace remaining inline color styles with themed Text where appropriate
- Optional PageContainer/PageSection primitives for consistent spacing
